### PR TITLE
CUDA aware MPI実装

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,11 +3,20 @@
     "build": {
         "dockerfile": "Dockerfile"
     },
+    "features": {
+        "ghcr.io/devcontainers/features/common-utils:2": {
+            "username": "vscode", // create a non-root user
+            "uid": "auto", // automatically adjust to host
+            "gid": "auto",
+            "non-root": true
+        }
+    },
     "runArgs": [
         "--gpus",
         "all"
     ],
-    // "remoteUser": "vscode",
+    "remoteUser": "vscode",
+    "updateRemoteUserUID": true, // overwrite UID/GID with host UID/GID
     "customizations": {
         "vscode": {
             "extensions": [

--- a/include/cuda_manager.cuh
+++ b/include/cuda_manager.cuh
@@ -1,5 +1,6 @@
 #pragma once
 #include "grid_cpu.hpp"
+#include "mpi_manager.hpp"
 #include <cuda_runtime.h>
 
 // clang-format off
@@ -27,10 +28,11 @@ template <typename Real> struct CudaManager {
   cudaStream_t stream_ei;
   cudaStream_t stream_ph;
 
-  dim3 grid_dim;
+  dim3 grid_dim, grid_dim_x_margin, grid_dim_y_margin, grid_dim_z_margin;
   dim3 block_dim;
 
   CudaManager(const Grid<Real> &grid) {
+
     CUDA_CHECK(cudaStreamCreate(&stream_ro));
     CUDA_CHECK(cudaStreamCreate(&stream_vx));
     CUDA_CHECK(cudaStreamCreate(&stream_vy));
@@ -45,5 +47,17 @@ template <typename Real> struct CudaManager {
     grid_dim = dim3((grid.i_total + block_dim.x - 1) / block_dim.x,
                     (grid.j_total + block_dim.y - 1) / block_dim.y,
                     (grid.k_total + block_dim.z - 1) / block_dim.z);
+
+    grid_dim_x_margin = dim3((grid.i_margin + block_dim.x - 1) / block_dim.x,
+                             (grid.j_total + block_dim.y - 1) / block_dim.y,
+                             (grid.k_total + block_dim.z - 1) / block_dim.z);
+
+    grid_dim_y_margin = dim3((grid.i_total + block_dim.x - 1) / block_dim.x,
+                             (grid.j_margin + block_dim.y - 1) / block_dim.y,
+                             (grid.k_total + block_dim.z - 1) / block_dim.z);
+
+    grid_dim_z_margin = dim3((grid.i_total + block_dim.x - 1) / block_dim.x,
+                             (grid.j_total + block_dim.y - 1) / block_dim.y,
+                             (grid.k_margin + block_dim.z - 1) / block_dim.z);
   }
 };

--- a/include/mhd_gpu.cuh
+++ b/include/mhd_gpu.cuh
@@ -1,8 +1,188 @@
 #pragma once
+#ifdef USE_CUDA
 #include "cuda_manager.cuh"
+#include "grid_gpu.cuh"
+#include "mpi_manager.hpp"
 #include <cassert>
 
+constexpr int n_var = 9;
+
+template <typename Real> struct MHDCoreDevice;
+
+enum class Face { Pos, Neg };
+
+// ##################
+// x-direction send
+template <typename Real>
+__global__ void pack_x_send(MHDCoreDevice<Real> qq_trgt,
+                            const GridDevice<Real> grid, Face face) {
+  const int i = blockIdx.x * blockDim.x + threadIdx.x;
+  const int j = blockIdx.y * blockDim.y + threadIdx.y;
+  const int k = blockIdx.z * blockDim.z + threadIdx.z;
+
+  if (i >= grid.i_margin || j >= grid.j_total || k >= grid.k_total)
+    return;
+
+  Real *__restrict__ send_buff =
+      (face == Face::Pos) ? qq_trgt.send_buff_x_pos : qq_trgt.send_buff_x_neg;
+
+  const int i_src = (face == Face::Pos) ? (grid.i_total - 2 * grid.i_margin + i)
+                                        : (grid.i_margin + i);
+  const size_t src_idx = grid.idx(i_src, j, k);
+  const size_t buf_idx = ((i * grid.j_total + j) * grid.k_total + k) * n_var;
+
+  const Real *__restrict__ var[n_var] = {qq_trgt.ro, qq_trgt.vx, qq_trgt.vy,
+                                         qq_trgt.vz, qq_trgt.bx, qq_trgt.by,
+                                         qq_trgt.bz, qq_trgt.ei, qq_trgt.ph};
+
+#pragma unroll
+  for (int m = 0; m < n_var; ++m) {
+    send_buff[buf_idx + m] = var[m][src_idx];
+  }
+};
+
+// y-direction send
+template <typename Real>
+__global__ void pack_y_send(MHDCoreDevice<Real> qq_trgt,
+                            const GridDevice<Real> grid, Face face) {
+  const int i = blockIdx.x * blockDim.x + threadIdx.x;
+  const int j = blockIdx.y * blockDim.y + threadIdx.y;
+  const int k = blockIdx.z * blockDim.z + threadIdx.z;
+
+  if (i >= grid.i_total || j >= grid.j_margin || k >= grid.k_total)
+    return;
+
+  Real *__restrict__ send_buff =
+      (face == Face::Pos) ? qq_trgt.send_buff_y_pos : qq_trgt.send_buff_y_neg;
+
+  const int j_src = (face == Face::Pos) ? (grid.j_total - 2 * grid.j_margin + j)
+                                        : (grid.j_margin + j);
+  const size_t src_idx = grid.idx(i, j_src, k);
+  const size_t buf_idx = ((i * grid.j_total + j) * grid.k_total + k) * n_var;
+
+  const Real *__restrict__ var[n_var] = {qq_trgt.ro, qq_trgt.vx, qq_trgt.vy,
+                                         qq_trgt.vz, qq_trgt.bx, qq_trgt.by,
+                                         qq_trgt.bz, qq_trgt.ei, qq_trgt.ph};
+
+#pragma unroll
+  for (int m = 0; m < n_var; ++m) {
+    send_buff[buf_idx + m] = var[m][src_idx];
+  }
+};
+
+// z-direction send
+template <typename Real>
+__global__ void pack_z_send(MHDCoreDevice<Real> qq_trgt,
+                            const GridDevice<Real> grid, Face face) {
+  const int i = blockIdx.x * blockDim.x + threadIdx.x;
+  const int j = blockIdx.y * blockDim.y + threadIdx.y;
+  const int k = blockIdx.z * blockDim.z + threadIdx.z;
+
+  if (i >= grid.i_total || j >= grid.j_total || k >= grid.k_margin)
+    return;
+
+  Real *__restrict__ send_buff =
+      (face == Face::Pos) ? qq_trgt.send_buff_z_pos : qq_trgt.send_buff_z_neg;
+
+  const int k_src = (face == Face::Pos) ? (grid.k_total - 2 * grid.k_margin + k)
+                                        : (grid.k_margin + k);
+  const size_t src_idx = grid.idx(i, j, k_src);
+  const size_t buf_idx = ((i * grid.j_total + j) * grid.k_total + k) * n_var;
+
+  const Real *__restrict__ var[n_var] = {qq_trgt.ro, qq_trgt.vx, qq_trgt.vy,
+                                         qq_trgt.vz, qq_trgt.bx, qq_trgt.by,
+                                         qq_trgt.bz, qq_trgt.ei, qq_trgt.ph};
+
+#pragma unroll
+  for (int m = 0; m < n_var; ++m) {
+    send_buff[buf_idx + m] = var[m][src_idx];
+  }
+};
+
+// ##################
+// x-direction recv
+template <typename Real>
+__global__ void unpack_x_recv(MHDCoreDevice<Real> qq_trgt,
+                              const GridDevice<Real> grid, Face face) {
+  const int i = blockIdx.x * blockDim.x + threadIdx.x;
+  const int j = blockIdx.y * blockDim.y + threadIdx.y;
+  const int k = blockIdx.z * blockDim.z + threadIdx.z;
+
+  if (i >= grid.i_margin || j >= grid.j_total || k >= grid.k_total)
+    return;
+  Real *__restrict__ recv_buff =
+      (face == Face::Pos) ? qq_trgt.recv_buff_x_pos : qq_trgt.recv_buff_x_neg;
+  const int i_tgt = (face == Face::Pos) ? grid.i_total - grid.i_margin + i : i;
+
+  const size_t tgt_idx = grid.idx(i_tgt, j, k);
+  const size_t buf_idx = ((i * grid.j_total + j) * grid.k_total + k) * n_var;
+
+  Real *__restrict__ var[n_var] = {qq_trgt.ro, qq_trgt.vx, qq_trgt.vy,
+                                   qq_trgt.vz, qq_trgt.bx, qq_trgt.by,
+                                   qq_trgt.bz, qq_trgt.ei, qq_trgt.ph};
+
+#pragma unroll
+  for (int m = 0; m < n_var; ++m) {
+    var[m][tgt_idx] = recv_buff[buf_idx + m];
+  }
+};
+
+// y-direction recv
+template <typename Real>
+__global__ void unpack_y_recv(MHDCoreDevice<Real> qq_trgt,
+                              const GridDevice<Real> grid, Face face) {
+  const int i = blockIdx.x * blockDim.x + threadIdx.x;
+  const int j = blockIdx.y * blockDim.y + threadIdx.y;
+  const int k = blockIdx.z * blockDim.z + threadIdx.z;
+
+  if (i >= grid.i_total || j >= grid.j_margin || k >= grid.k_total)
+    return;
+  Real *__restrict__ recv_buff =
+      (face == Face::Pos) ? qq_trgt.recv_buff_y_pos : qq_trgt.recv_buff_y_neg;
+  const int j_tgt = (face == Face::Pos) ? grid.j_total - grid.j_margin + j : j;
+
+  const size_t tgt_idx = grid.idx(i, j_tgt, k);
+  const size_t buf_idx = ((i * grid.j_total + j) * grid.k_total + k) * n_var;
+
+  Real *__restrict__ var[n_var] = {qq_trgt.ro, qq_trgt.vx, qq_trgt.vy,
+                                   qq_trgt.vz, qq_trgt.bx, qq_trgt.by,
+                                   qq_trgt.bz, qq_trgt.ei, qq_trgt.ph};
+
+#pragma unroll
+  for (int m = 0; m < n_var; ++m) {
+    var[m][tgt_idx] = recv_buff[buf_idx + m];
+  }
+};
+
+// z-direction recv
+template <typename Real>
+__global__ void unpack_z_recv(MHDCoreDevice<Real> qq_trgt,
+                              const GridDevice<Real> grid, Face face) {
+  const int i = blockIdx.x * blockDim.x + threadIdx.x;
+  const int j = blockIdx.y * blockDim.y + threadIdx.y;
+  const int k = blockIdx.z * blockDim.z + threadIdx.z;
+
+  if (i >= grid.i_total || j >= grid.j_total || k >= grid.k_margin)
+    return;
+  Real *__restrict__ recv_buff =
+      (face == Face::Pos) ? qq_trgt.recv_buff_z_pos : qq_trgt.recv_buff_z_neg;
+  const int k_tgt = (face == Face::Pos) ? grid.k_total - grid.k_margin + k : k;
+
+  const size_t tgt_idx = grid.idx(i, j, k_tgt);
+  const size_t buf_idx = ((i * grid.j_total + j) * grid.k_total + k) * n_var;
+
+  Real *__restrict__ var[n_var] = {qq_trgt.ro, qq_trgt.vx, qq_trgt.vy,
+                                   qq_trgt.vz, qq_trgt.bx, qq_trgt.by,
+                                   qq_trgt.bz, qq_trgt.ei, qq_trgt.ph};
+
+#pragma unroll
+  for (int m = 0; m < n_var; ++m) {
+    var[m][tgt_idx] = recv_buff[buf_idx + m];
+  }
+};
+
 template <typename Real> struct MHDCoreDevice {
+
   Real *ro = nullptr;
   Real *vx = nullptr;
   Real *vy = nullptr;
@@ -13,51 +193,68 @@ template <typename Real> struct MHDCoreDevice {
   Real *ei = nullptr;
   Real *ph = nullptr;
 
+  Real *recv_buff_x_pos = nullptr;
+  Real *recv_buff_x_neg = nullptr;
+  Real *recv_buff_y_pos = nullptr;
+  Real *recv_buff_y_neg = nullptr;
+  Real *recv_buff_z_pos = nullptr;
+  Real *recv_buff_z_neg = nullptr;
+  Real *send_buff_x_pos = nullptr;
+  Real *send_buff_x_neg = nullptr;
+  Real *send_buff_y_pos = nullptr;
+  Real *send_buff_y_neg = nullptr;
+  Real *send_buff_z_pos = nullptr;
+  Real *send_buff_z_neg = nullptr;
+
   int i_total, j_total, k_total;
 
-  MHDCoreDevice(const Grid<Real> &grid)
-      : i_total(grid.i_total), j_total(grid.j_total), k_total(grid.k_total) {
-    CUDA_CHECK(cudaMalloc(&ro, sizeof(Real) * i_total * j_total * k_total));
-    CUDA_CHECK(cudaMalloc(&vx, sizeof(Real) * i_total * j_total * k_total));
-    CUDA_CHECK(cudaMalloc(&vy, sizeof(Real) * i_total * j_total * k_total));
-    CUDA_CHECK(cudaMalloc(&vz, sizeof(Real) * i_total * j_total * k_total));
-    CUDA_CHECK(cudaMalloc(&bx, sizeof(Real) * i_total * j_total * k_total));
-    CUDA_CHECK(cudaMalloc(&by, sizeof(Real) * i_total * j_total * k_total));
-    CUDA_CHECK(cudaMalloc(&bz, sizeof(Real) * i_total * j_total * k_total));
-    CUDA_CHECK(cudaMalloc(&ei, sizeof(Real) * i_total * j_total * k_total));
-    CUDA_CHECK(cudaMalloc(&ph, sizeof(Real) * i_total * j_total * k_total));
-  }
+  // clang-format off
+    MHDCoreDevice(const Grid<Real> &grid)
+        : i_total(grid.i_total), j_total(grid.j_total), k_total(grid.k_total) {
+      CUDA_CHECK(cudaMalloc(&ro, sizeof(Real) * i_total * j_total * k_total));
+      CUDA_CHECK(cudaMalloc(&vx, sizeof(Real) * i_total * j_total * k_total));
+      CUDA_CHECK(cudaMalloc(&vy, sizeof(Real) * i_total * j_total * k_total));
+      CUDA_CHECK(cudaMalloc(&vz, sizeof(Real) * i_total * j_total * k_total));
+      CUDA_CHECK(cudaMalloc(&bx, sizeof(Real) * i_total * j_total * k_total));
+      CUDA_CHECK(cudaMalloc(&by, sizeof(Real) * i_total * j_total * k_total));
+      CUDA_CHECK(cudaMalloc(&bz, sizeof(Real) * i_total * j_total * k_total));
+      CUDA_CHECK(cudaMalloc(&ei, sizeof(Real) * i_total * j_total * k_total));
+      CUDA_CHECK(cudaMalloc(&ph, sizeof(Real) * i_total * j_total * k_total));
+      CUDA_CHECK(cudaMalloc(&recv_buff_x_pos, sizeof(Real) * grid.i_margin * j_total * k_total * n_var));
+      CUDA_CHECK(cudaMalloc(&recv_buff_x_neg, sizeof(Real) * grid.i_margin * j_total * k_total * n_var));
+      CUDA_CHECK(cudaMalloc(&recv_buff_y_pos, sizeof(Real) * grid.j_margin * i_total * k_total * n_var));
+      CUDA_CHECK(cudaMalloc(&recv_buff_y_neg, sizeof(Real) * grid.j_margin * i_total * k_total * n_var));
+      CUDA_CHECK(cudaMalloc(&recv_buff_z_pos, sizeof(Real) * grid.k_margin * i_total * j_total * n_var));
+      CUDA_CHECK(cudaMalloc(&recv_buff_z_neg, sizeof(Real) * grid.k_margin * i_total * j_total * n_var));
+      CUDA_CHECK(cudaMalloc(&send_buff_x_pos, sizeof(Real) * grid.i_margin * j_total * k_total * n_var));
+      CUDA_CHECK(cudaMalloc(&send_buff_x_neg, sizeof(Real) * grid.i_margin * j_total * k_total * n_var));
+      CUDA_CHECK(cudaMalloc(&send_buff_y_pos, sizeof(Real) * grid.j_margin * i_total * k_total * n_var));
+      CUDA_CHECK(cudaMalloc(&send_buff_y_neg, sizeof(Real) * grid.j_margin * i_total * k_total * n_var));
+      CUDA_CHECK(cudaMalloc(&send_buff_z_pos, sizeof(Real) * grid.k_margin * i_total * j_total * n_var));
+      CUDA_CHECK(cudaMalloc(&send_buff_z_neg, sizeof(Real) * grid.k_margin * i_total * j_total * n_var));
+    }
+  // clang-format on
 
   ~MHDCoreDevice() {}
 
   void free() {
-    if (ro)
-      CUDA_CHECK(cudaFree(ro));
-    ro = nullptr;
-    if (vx)
-      CUDA_CHECK(cudaFree(vx));
-    vx = nullptr;
-    if (vy)
-      CUDA_CHECK(cudaFree(vy));
-    vy = nullptr;
-    if (vz)
-      CUDA_CHECK(cudaFree(vz));
-    vz = nullptr;
-    if (bx)
-      CUDA_CHECK(cudaFree(bx));
-    bx = nullptr;
-    if (by)
-      CUDA_CHECK(cudaFree(by));
-    by = nullptr;
-    if (bz)
-      CUDA_CHECK(cudaFree(bz));
-    bz = nullptr;
-    if (ei)
-      CUDA_CHECK(cudaFree(ei));
-    ei = nullptr;
-    if (ph)
-      CUDA_CHECK(cudaFree(ph));
-    ph = nullptr;
+    auto F = [](Real *&p) {
+      if (p)
+        CUDA_CHECK(cudaFree(p));
+      p = nullptr;
+    };
+    // clang-format off
+      // fields
+      F(ro); F(vx); F(vy); F(vz); F(bx); F(by); F(bz); F(ei); F(ph);
+
+      // buffers
+      F(recv_buff_x_pos); F(recv_buff_x_neg);
+      F(recv_buff_y_pos); F(recv_buff_y_neg);
+      F(recv_buff_z_pos); F(recv_buff_z_neg);
+      F(send_buff_x_pos); F(send_buff_x_neg);
+      F(send_buff_y_pos); F(send_buff_y_neg);
+      F(send_buff_z_pos); F(send_buff_z_neg);
+    // clang-format on
   }
 
   MHDCoreDevice(const MHDCoreDevice &) = default;
@@ -185,4 +382,166 @@ template <typename Real> struct MHDDevice {
 
   MHDDevice(const MHDDevice &) = default;
   MHDDevice &operator=(const MHDDevice &) = default;
+
+  void mpi_exchange_halo(MHDCoreDevice<Real> &qq_trgt, GridDevice<Real> &grid,
+                         MPIManager<Real> &mpi, CudaManager<Real> &cuda) {
+    MPI_Request reqs[12];
+    int req_count = 0;
+
+    // ##################
+    // positive x-direction
+    if (mpi.x_procs_pos != MPI_PROC_NULL && grid.i_total > 1) {
+      pack_x_send<<<cuda.grid_dim_x_margin, cuda.block_dim>>>(qq_trgt, grid,
+                                                              Face::Pos);
+      CUDA_CHECK(cudaGetLastError());
+      CUDA_CHECK(cudaDeviceSynchronize());
+
+      MPI_Isend(qq_trgt.send_buff_x_pos,
+                grid.i_margin * grid.j_total * grid.k_total * n_var,
+                mpi_type<Real>(), mpi.x_procs_pos, 100, mpi.cart_comm,
+                &reqs[req_count++]);
+      MPI_Irecv(qq_trgt.recv_buff_x_pos,
+                grid.i_margin * grid.j_total * grid.k_total * n_var,
+                mpi_type<Real>(), mpi.x_procs_pos, 200, mpi.cart_comm,
+                &reqs[req_count++]);
+    }
+
+    // positive y-direction
+    if (mpi.y_procs_pos != MPI_PROC_NULL && grid.j_total > 1) {
+      pack_y_send<<<cuda.grid_dim_y_margin, cuda.block_dim>>>(qq_trgt, grid,
+                                                              Face::Pos);
+      CUDA_CHECK(cudaGetLastError());
+      CUDA_CHECK(cudaDeviceSynchronize());
+
+      MPI_Isend(qq_trgt.send_buff_y_pos,
+                grid.i_total * grid.j_margin * grid.k_total * n_var,
+                mpi_type<Real>(), mpi.y_procs_pos, 300, mpi.cart_comm,
+                &reqs[req_count++]);
+      MPI_Irecv(qq_trgt.recv_buff_y_pos,
+                grid.i_total * grid.j_margin * grid.k_total * n_var,
+                mpi_type<Real>(), mpi.y_procs_pos, 400, mpi.cart_comm,
+                &reqs[req_count++]);
+    }
+
+    // positive z-direction
+    if (mpi.z_procs_pos != MPI_PROC_NULL && grid.k_total > 1) {
+      pack_z_send<<<cuda.grid_dim_z_margin, cuda.block_dim>>>(qq_trgt, grid,
+                                                              Face::Pos);
+      CUDA_CHECK(cudaGetLastError());
+      CUDA_CHECK(cudaDeviceSynchronize());
+
+      MPI_Isend(qq_trgt.send_buff_z_pos,
+                grid.i_total * grid.j_total * grid.k_margin * n_var,
+                mpi_type<Real>(), mpi.z_procs_pos, 500, mpi.cart_comm,
+                &reqs[req_count++]);
+      MPI_Irecv(qq_trgt.recv_buff_z_pos,
+                grid.i_total * grid.j_total * grid.k_margin * n_var,
+                mpi_type<Real>(), mpi.z_procs_pos, 600, mpi.cart_comm,
+                &reqs[req_count++]);
+    }
+
+    // ##################
+    // negative x-direction
+    if (mpi.x_procs_neg != MPI_PROC_NULL && grid.i_total > 1) {
+      pack_x_send<<<cuda.grid_dim_x_margin, cuda.block_dim>>>(qq_trgt, grid,
+                                                              Face::Neg);
+      CUDA_CHECK(cudaGetLastError());
+      CUDA_CHECK(cudaDeviceSynchronize());
+      MPI_Isend(qq_trgt.send_buff_x_neg,
+                grid.i_margin * grid.j_total * grid.k_total * n_var,
+                mpi_type<Real>(), mpi.x_procs_neg, 200, mpi.cart_comm,
+                &reqs[req_count++]);
+      MPI_Irecv(qq_trgt.recv_buff_x_neg,
+                grid.i_margin * grid.j_total * grid.k_total * n_var,
+                mpi_type<Real>(), mpi.x_procs_neg, 100, mpi.cart_comm,
+                &reqs[req_count++]);
+    }
+
+    // negative y-direction
+    if (mpi.y_procs_neg != MPI_PROC_NULL && grid.j_total > 1) {
+      pack_y_send<<<cuda.grid_dim_y_margin, cuda.block_dim>>>(qq_trgt, grid,
+                                                              Face::Neg);
+      CUDA_CHECK(cudaGetLastError());
+      CUDA_CHECK(cudaDeviceSynchronize());
+      MPI_Isend(qq_trgt.send_buff_y_neg,
+                grid.i_total * grid.j_margin * grid.k_total * n_var,
+                mpi_type<Real>(), mpi.y_procs_neg, 400, mpi.cart_comm,
+                &reqs[req_count++]);
+      MPI_Irecv(qq_trgt.recv_buff_y_neg,
+                grid.i_total * grid.j_margin * grid.k_total * n_var,
+                mpi_type<Real>(), mpi.y_procs_neg, 300, mpi.cart_comm,
+                &reqs[req_count++]);
+    }
+
+    // negative z-direction
+    if (mpi.z_procs_neg != MPI_PROC_NULL && grid.k_total > 1) {
+      pack_z_send<<<cuda.grid_dim_z_margin, cuda.block_dim>>>(qq_trgt, grid,
+                                                              Face::Neg);
+      CUDA_CHECK(cudaGetLastError());
+      CUDA_CHECK(cudaDeviceSynchronize());
+      MPI_Isend(qq_trgt.send_buff_z_neg,
+                grid.i_total * grid.j_total * grid.k_margin * n_var,
+                mpi_type<Real>(), mpi.z_procs_neg, 600, mpi.cart_comm,
+                &reqs[req_count++]);
+      MPI_Irecv(qq_trgt.recv_buff_z_neg,
+                grid.i_total * grid.j_total * grid.k_margin * n_var,
+                mpi_type<Real>(), mpi.z_procs_neg, 500, mpi.cart_comm,
+                &reqs[req_count++]);
+    }
+
+    if (req_count > 0) {
+      MPI_Waitall(req_count, reqs, MPI_STATUSES_IGNORE);
+    }
+
+    // ##################
+    // positive x-direction
+    if (mpi.x_procs_pos != MPI_PROC_NULL && grid.i_total > 1) {
+      unpack_x_recv<<<cuda.grid_dim_x_margin, cuda.block_dim>>>(qq_trgt, grid,
+                                                                Face::Pos);
+      CUDA_CHECK(cudaGetLastError());
+      CUDA_CHECK(cudaDeviceSynchronize());
+    }
+
+    // positive y-direction
+    if (mpi.y_procs_pos != MPI_PROC_NULL && grid.j_total > 1) {
+      unpack_y_recv<<<cuda.grid_dim_y_margin, cuda.block_dim>>>(qq_trgt, grid,
+                                                                Face::Pos);
+      CUDA_CHECK(cudaGetLastError());
+      CUDA_CHECK(cudaDeviceSynchronize());
+    }
+
+    // positive z-direction
+    if (mpi.z_procs_pos != MPI_PROC_NULL && grid.k_total > 1) {
+      unpack_z_recv<<<cuda.grid_dim_z_margin, cuda.block_dim>>>(qq_trgt, grid,
+                                                                Face::Pos);
+      CUDA_CHECK(cudaGetLastError());
+      CUDA_CHECK(cudaDeviceSynchronize());
+    }
+
+    // ##################
+    // negative x-direction
+    if (mpi.x_procs_neg != MPI_PROC_NULL && grid.i_total > 1) {
+      unpack_x_recv<<<cuda.grid_dim_x_margin, cuda.block_dim>>>(qq_trgt, grid,
+                                                                Face::Neg);
+      CUDA_CHECK(cudaGetLastError());
+      CUDA_CHECK(cudaDeviceSynchronize());
+    }
+
+    // negative y-direction
+    if (mpi.y_procs_neg != MPI_PROC_NULL && grid.j_total > 1) {
+      unpack_y_recv<<<cuda.grid_dim_y_margin, cuda.block_dim>>>(qq_trgt, grid,
+                                                                Face::Neg);
+      CUDA_CHECK(cudaGetLastError());
+      CUDA_CHECK(cudaDeviceSynchronize());
+    }
+
+    // negative z-direction
+    if (mpi.z_procs_neg != MPI_PROC_NULL && grid.k_total > 1) {
+      unpack_z_recv<<<cuda.grid_dim_z_margin, cuda.block_dim>>>(qq_trgt, grid,
+                                                                Face::Neg);
+      CUDA_CHECK(cudaGetLastError());
+      CUDA_CHECK(cudaDeviceSynchronize());
+    }
+  }
 };
+#endif

--- a/include/mhd_gpu.cuh
+++ b/include/mhd_gpu.cuh
@@ -58,7 +58,7 @@ __global__ void pack_y_send(MHDCoreDevice<Real> qq_trgt,
   const int j_src = (face == Face::Pos) ? (grid.j_total - 2 * grid.j_margin + j)
                                         : (grid.j_margin + j);
   const size_t src_idx = grid.idx(i, j_src, k);
-  const size_t buf_idx = ((i * grid.j_total + j) * grid.k_total + k) * n_var;
+  const size_t buf_idx = ((i * grid.j_margin + j) * grid.k_total + k) * n_var;
 
   const Real *__restrict__ var[n_var] = {qq_trgt.ro, qq_trgt.vx, qq_trgt.vy,
                                          qq_trgt.vz, qq_trgt.bx, qq_trgt.by,
@@ -87,7 +87,7 @@ __global__ void pack_z_send(MHDCoreDevice<Real> qq_trgt,
   const int k_src = (face == Face::Pos) ? (grid.k_total - 2 * grid.k_margin + k)
                                         : (grid.k_margin + k);
   const size_t src_idx = grid.idx(i, j, k_src);
-  const size_t buf_idx = ((i * grid.j_total + j) * grid.k_total + k) * n_var;
+  const size_t buf_idx = ((i * grid.j_total + j) * grid.k_margin + k) * n_var;
 
   const Real *__restrict__ var[n_var] = {qq_trgt.ro, qq_trgt.vx, qq_trgt.vy,
                                          qq_trgt.vz, qq_trgt.bx, qq_trgt.by,
@@ -142,7 +142,7 @@ __global__ void unpack_y_recv(MHDCoreDevice<Real> qq_trgt,
   const int j_tgt = (face == Face::Pos) ? grid.j_total - grid.j_margin + j : j;
 
   const size_t tgt_idx = grid.idx(i, j_tgt, k);
-  const size_t buf_idx = ((i * grid.j_total + j) * grid.k_total + k) * n_var;
+  const size_t buf_idx = ((i * grid.j_margin + j) * grid.k_total + k) * n_var;
 
   Real *__restrict__ var[n_var] = {qq_trgt.ro, qq_trgt.vx, qq_trgt.vy,
                                    qq_trgt.vz, qq_trgt.bx, qq_trgt.by,
@@ -169,7 +169,7 @@ __global__ void unpack_z_recv(MHDCoreDevice<Real> qq_trgt,
   const int k_tgt = (face == Face::Pos) ? grid.k_total - grid.k_margin + k : k;
 
   const size_t tgt_idx = grid.idx(i, j, k_tgt);
-  const size_t buf_idx = ((i * grid.j_total + j) * grid.k_total + k) * n_var;
+  const size_t buf_idx = ((i * grid.j_total + j) * grid.k_margin + k) * n_var;
 
   Real *__restrict__ var[n_var] = {qq_trgt.ro, qq_trgt.vx, qq_trgt.vy,
                                    qq_trgt.vz, qq_trgt.bx, qq_trgt.by,

--- a/include/mpi_manager.hpp
+++ b/include/mpi_manager.hpp
@@ -5,6 +5,10 @@
 #include <mpi.h>
 #include <yaml-cpp/yaml.h>
 
+#ifdef USE_CUDA
+#include <cuda_runtime.h>
+#endif
+
 template <typename Real> struct MPIManager {
   MPI_Comm cart_comm = MPI_COMM_NULL;
   int myrank = -1;
@@ -83,5 +87,9 @@ template <typename Real> struct MPIManager {
   void setup_mpi(YAML::Node &yaml_obj) {
     init_parameters(yaml_obj);
     set_cart_comm(yaml_obj);
+
+#ifdef USE_CUDA
+    cudaSetDevice(myrank);
+#endif
   }
 };

--- a/problems/CMakeLists.txt
+++ b/problems/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(PROBLEM_EXECUTABLES)
 
 foreach(PROBLEM_DIR
+        cuda_test
         hd_shock_tube_1d
         mhd_shock_tube_1d
         mhd_vortex_2d

--- a/problems/CMakeLists.txt
+++ b/problems/CMakeLists.txt
@@ -1,7 +1,6 @@
 set(PROBLEM_EXECUTABLES)
 
 foreach(PROBLEM_DIR
-        cuda_test
         hd_shock_tube_1d
         mhd_shock_tube_1d
         mhd_vortex_2d
@@ -11,5 +10,10 @@ foreach(PROBLEM_DIR
     add_subdirectory(${PROBLEM_DIR})
     list(APPEND PROBLEM_EXECUTABLES ${PROBLEM_DIR})
 endforeach()
+
+if(USE_CUDA)
+    add_subdirectory(cuda_test)
+    list(APPEND PROBLEM_EXECUTABLES cuda_test)
+endif()
 
 add_custom_target(all_problems DEPENDS ${PROBLEM_EXECUTABLES})

--- a/problems/cuda_test/CMakeLists.txt
+++ b/problems/cuda_test/CMakeLists.txt
@@ -16,3 +16,16 @@ add_custom_target(clean_data_${PROBLEM_NAME}
   COMMAND /bin/sh -c "rm -rf ${CMAKE_SOURCE_DIR}/problems/${PROBLEM_NAME}/data*"
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/problems/${PROBLEM_NAME}
 )
+
+function(enable_always_assert_for target)
+  # C/C++
+  target_compile_options(${target} PRIVATE
+    $<$<COMPILE_LANGUAGE:C>:-UNDEBUG>
+    $<$<COMPILE_LANGUAGE:CXX>:-UNDEBUG>
+  )
+  # CUDA（デバイス側にも、ホスト側コンパイラにも伝える）
+  target_compile_options(${target} PRIVATE
+    $<$<COMPILE_LANGUAGE:CUDA>:-UNDEBUG;-Xcompiler=-UNDEBUG>
+  )
+endfunction()
+enable_always_assert_for(${PROBLEM_NAME})

--- a/problems/cuda_test/config_x.yaml
+++ b/problems/cuda_test/config_x.yaml
@@ -12,9 +12,9 @@ time:
   n_output_digits: 8
 
 grid:
-  i_size: 12
-  j_size: 13
-  k_size: 14
+  i_size: 3
+  j_size: 4
+  k_size: 5
   margin: 2
   xmin: 0.0
   xmax: 1.0
@@ -26,7 +26,7 @@ grid:
 mpi:
   mpi_save_dir: mpi/
   n_procs_digits: 8
-  x_procs: 1
+  x_procs: 2
   y_procs: 1
   z_procs: 1
 
@@ -51,9 +51,9 @@ boundary_condition:
   boundary_type: standard
 
   periodic:
-    x: true
-    y: true
-    z: true
+    x: false
+    y: false
+    z: false
 
   ro:
     x: [symmetric, symmetric]

--- a/problems/cuda_test/config_y.yaml
+++ b/problems/cuda_test/config_y.yaml
@@ -1,0 +1,101 @@
+base:
+  save_dir: data/
+  # if save_dir exiests
+  # continue: true -> continue simulation
+  # continue: false -> start from scratch
+  continue: true
+
+time:
+  time_save_dir: time/
+  tend: 0.8
+  dt_output: 0.01
+  n_output_digits: 8
+
+grid:
+  i_size: 3
+  j_size: 4
+  k_size: 5
+  margin: 2
+  xmin: 0.0
+  xmax: 1.0
+  ymin: 0.0
+  ymax: 2.0
+  zmin: 0.0
+  zmax: 3.0
+
+mpi:
+  mpi_save_dir: mpi/
+  n_procs_digits: 8
+  x_procs: 1
+  y_procs: 2
+  z_procs: 1
+
+mhd:
+  mhd_save_dir: mhd/
+
+eos:
+  gm: 1.6666666666666667
+
+time_integrator:
+  cfl_number: 0.5
+
+artificial_viscosity:
+  ep: 1.5
+  fh: 1.0
+  # for characteristic velocity
+  cs_fac: 0.5
+  ca_fac: 1.0
+  vv_fac: 1.0
+boundary_condition:
+  # please use "standard" or "custom" for boundary_type
+  boundary_type: standard
+
+  periodic:
+    x: false
+    y: false
+    z: false
+
+  ro:
+    x: [symmetric, symmetric]
+    y: [symmetric, symmetric]
+    z: [symmetric, symmetric]
+
+  vx:
+    x: [symmetric, symmetric]
+    y: [symmetric, symmetric]
+    z: [symmetric, symmetric]
+
+  vy:
+    x: [symmetric, symmetric]
+    y: [symmetric, symmetric]
+    z: [symmetric, symmetric]
+
+  vz:
+    x: [symmetric, symmetric]
+    y: [symmetric, symmetric]
+    z: [symmetric, symmetric]
+
+  bx:
+    x: [symmetric, symmetric]
+    y: [symmetric, symmetric]
+    z: [symmetric, symmetric]
+
+  by:
+    x: [symmetric, symmetric]
+    y: [symmetric, symmetric]
+    z: [symmetric, symmetric]
+
+  bz:
+    x: [symmetric, symmetric]
+    y: [symmetric, symmetric]
+    z: [symmetric, symmetric]
+
+  ei:
+    x: [symmetric, symmetric]
+    y: [symmetric, symmetric]
+    z: [symmetric, symmetric]
+
+  ph:
+    x: [symmetric, symmetric]
+    y: [symmetric, symmetric]
+    z: [symmetric, symmetric]

--- a/problems/cuda_test/config_z.yaml
+++ b/problems/cuda_test/config_z.yaml
@@ -1,0 +1,101 @@
+base:
+  save_dir: data/
+  # if save_dir exiests
+  # continue: true -> continue simulation
+  # continue: false -> start from scratch
+  continue: true
+
+time:
+  time_save_dir: time/
+  tend: 0.8
+  dt_output: 0.01
+  n_output_digits: 8
+
+grid:
+  i_size: 3
+  j_size: 4
+  k_size: 5
+  margin: 2
+  xmin: 0.0
+  xmax: 1.0
+  ymin: 0.0
+  ymax: 2.0
+  zmin: 0.0
+  zmax: 3.0
+
+mpi:
+  mpi_save_dir: mpi/
+  n_procs_digits: 8
+  x_procs: 1
+  y_procs: 1
+  z_procs: 2
+
+mhd:
+  mhd_save_dir: mhd/
+
+eos:
+  gm: 1.6666666666666667
+
+time_integrator:
+  cfl_number: 0.5
+
+artificial_viscosity:
+  ep: 1.5
+  fh: 1.0
+  # for characteristic velocity
+  cs_fac: 0.5
+  ca_fac: 1.0
+  vv_fac: 1.0
+boundary_condition:
+  # please use "standard" or "custom" for boundary_type
+  boundary_type: standard
+
+  periodic:
+    x: false
+    y: false
+    z: false
+
+  ro:
+    x: [symmetric, symmetric]
+    y: [symmetric, symmetric]
+    z: [symmetric, symmetric]
+
+  vx:
+    x: [symmetric, symmetric]
+    y: [symmetric, symmetric]
+    z: [symmetric, symmetric]
+
+  vy:
+    x: [symmetric, symmetric]
+    y: [symmetric, symmetric]
+    z: [symmetric, symmetric]
+
+  vz:
+    x: [symmetric, symmetric]
+    y: [symmetric, symmetric]
+    z: [symmetric, symmetric]
+
+  bx:
+    x: [symmetric, symmetric]
+    y: [symmetric, symmetric]
+    z: [symmetric, symmetric]
+
+  by:
+    x: [symmetric, symmetric]
+    y: [symmetric, symmetric]
+    z: [symmetric, symmetric]
+
+  bz:
+    x: [symmetric, symmetric]
+    y: [symmetric, symmetric]
+    z: [symmetric, symmetric]
+
+  ei:
+    x: [symmetric, symmetric]
+    y: [symmetric, symmetric]
+    z: [symmetric, symmetric]
+
+  ph:
+    x: [symmetric, symmetric]
+    y: [symmetric, symmetric]
+    z: [symmetric, symmetric]

--- a/problems/cuda_test/main.cu
+++ b/problems/cuda_test/main.cu
@@ -1,3 +1,9 @@
+#ifdef USE_CUDA
+#include "config.hpp"
+#include "model.hpp"
+#include "types.hpp"
+#include "utility.hpp"
+#include <cassert>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
@@ -6,18 +12,9 @@
 #include <string>
 #include <vector>
 
-#include "config.hpp"
-#include "model.hpp"
-#include "types.hpp"
-#include "utility.hpp"
-
-#ifdef USE_CUDA
 #include "cuda_manager.cuh"
 #include "cuda_runtime.h"
 #include "time_integrator_gpu.cuh"
-#else
-#include "time_integrator_cpu.hpp"
-#endif
 
 __global__ void initialize_density(MHDDevice<Real> mhd, int i_total, int j_total,
                                    int k_total) {
@@ -32,7 +29,7 @@ __global__ void initialize_density(MHDDevice<Real> mhd, int i_total, int j_total
 }
 
 int main() {
-  std::vector<std::string> directions = {"y"};
+  std::vector<std::string> directions = {"x", "y"};
 
   std::string config_dir = CONFIG_DIR;
   MPIManager<Real> mpi;
@@ -73,8 +70,6 @@ int main() {
             if (direction == "x") {
               if (mpi.myrank == 0 &&
                   i >= model.grid_local.i_total - model.grid_local.i_margin) {
-                std::cout << "i=" << i << ", j=" << j << ", k=" << k
-                          << ", ro=" << model.mhd.qq.ro(i, j, k) << std::endl;
                 assert(model.mhd.qq.ro(i, j, k) == 1);
               }
               if (mpi.myrank == 1 && i < model.grid_local.i_margin) {
@@ -83,11 +78,17 @@ int main() {
             } else if (direction == "y") {
               if (mpi.myrank == 0 &&
                   j >= model.grid_local.j_total - model.grid_local.j_margin) {
-                std::cout << "i=" << i << ", j=" << j << ", k=" << k
-                          << ", ro=" << model.mhd.qq.ro(i, j, k) << std::endl;
                 assert(model.mhd.qq.ro(i, j, k) == 1);
               }
               if (mpi.myrank == 1 && j < model.grid_local.j_margin) {
+                assert(model.mhd.qq.ro(i, j, k) == 0);
+              }
+            } else if (direction == "z") {
+              if (mpi.myrank == 0 &&
+                  k >= model.grid_local.k_total - model.grid_local.k_margin) {
+                assert(model.mhd.qq.ro(i, j, k) == 1);
+              }
+              if (mpi.myrank == 1 && k < model.grid_local.k_margin) {
                 assert(model.mhd.qq.ro(i, j, k) == 0);
               }
             }
@@ -100,3 +101,4 @@ int main() {
   }
   return 0;
 }
+#endif

--- a/problems/cuda_test/main.cu
+++ b/problems/cuda_test/main.cu
@@ -13,6 +13,7 @@
 
 #ifdef USE_CUDA
 #include "cuda_manager.cuh"
+#include "cuda_runtime.h"
 #include "time_integrator_gpu.cuh"
 #else
 #include "time_integrator_cpu.hpp"
@@ -26,56 +27,76 @@ __global__ void initialize_density(MHDDevice<Real> mhd, int i_total, int j_total
 
   if (i < i_total && j < j_total && k < k_total) {
     int idx = (i * j_total + j) * k_total + k;
-    mhd.qq.ro[idx] = mhd.qq.ro[idx] + 1.0;
+    mhd.qq.ro[idx] = mhd.qq.ro[idx];
   }
 }
 
 int main() {
+  std::vector<std::string> directions = {"y"};
+
   std::string config_dir = CONFIG_DIR;
   MPIManager<Real> mpi;
 
-  Config config(config_dir + "config.yaml", mpi);
-  mpi.setup_mpi(config.yaml_obj);
-  Model<Real> model(config);
-  model.save_metadata();
+  for (const auto &direction : directions) {
+    {
+      Config config(config_dir + "config_" + direction + ".yaml", mpi);
+      mpi.setup_mpi(config.yaml_obj);
+      // cudaSetDevice(mpi.myrank);
+      Model<Real> model(config);
+      model.save_metadata();
 
-  for (int i = 0; i < model.grid_local.i_total; ++i) {
-    for (int j = 0; j < model.grid_local.j_total; ++j) {
-      for (int k = 0; k < model.grid_local.k_total; ++k) {
-        model.mhd.qq.ro(i, j, k) = 1.0;
+      for (int i = 0; i < model.grid_local.i_total; ++i) {
+        for (int j = 0; j < model.grid_local.j_total; ++j) {
+          for (int k = 0; k < model.grid_local.k_total; ++k) {
+            model.mhd.qq.ro(i, j, k) = mpi.myrank;
+          }
+        }
       }
+
+      MHDDevice<Real> mhd_d(model.grid_local, model.mhd);
+      model.mhd_d.qq.copy_from_host(model.mhd.qq, model.cuda);
+
+      model.mhd_d.mpi_exchange_halo(model.mhd_d.qq, model.grid_d, model.mpi,
+                                    model.cuda);
+      initialize_density<<<model.cuda.grid_dim, model.cuda.block_dim>>>(
+          model.mhd_d, model.grid_local.i_total, model.grid_local.j_total,
+          model.grid_local.k_total);
+      CUDA_CHECK(cudaGetLastError());
+      CUDA_CHECK(cudaDeviceSynchronize());
+
+      cudaDeviceSynchronize();
+      model.mhd_d.qq.copy_to_host(model.mhd.qq, model.cuda);
+
+      for (int i = 0; i < model.grid_local.i_total; ++i) {
+        for (int j = 0; j < model.grid_local.j_total; ++j) {
+          for (int k = 0; k < model.grid_local.k_total; ++k) {
+            if (direction == "x") {
+              if (mpi.myrank == 0 &&
+                  i >= model.grid_local.i_total - model.grid_local.i_margin) {
+                std::cout << "i=" << i << ", j=" << j << ", k=" << k
+                          << ", ro=" << model.mhd.qq.ro(i, j, k) << std::endl;
+                assert(model.mhd.qq.ro(i, j, k) == 1);
+              }
+              if (mpi.myrank == 1 && i < model.grid_local.i_margin) {
+                assert(model.mhd.qq.ro(i, j, k) == 0);
+              }
+            } else if (direction == "y") {
+              if (mpi.myrank == 0 &&
+                  j >= model.grid_local.j_total - model.grid_local.j_margin) {
+                std::cout << "i=" << i << ", j=" << j << ", k=" << k
+                          << ", ro=" << model.mhd.qq.ro(i, j, k) << std::endl;
+                assert(model.mhd.qq.ro(i, j, k) == 1);
+              }
+              if (mpi.myrank == 1 && j < model.grid_local.j_margin) {
+                assert(model.mhd.qq.ro(i, j, k) == 0);
+              }
+            }
+          }
+        }
+      }
+
+      model.mhd_d.qq.free();
     }
   }
-
-  // MHDDevice<Real> mhd_d;
-  // mhd_d.allocate(grid);
-  // MHDCore<Real> qq_h(grid.i_total, grid.j_total, grid.k_total);
-
-  model.mhd_d.qq.copy_from_host(model.mhd.qq, cuda);
-
-  dim3 cuda_block(8, 8, 8);
-  dim3 cuda_grid((model.grid_local.i_total + 7) / 8,
-                 (model.grid_local.j_total + 7) / 8,
-                 (model.grid_local.k_total + 7) / 8);
-  initialize_density<<<cuda_grid, cuda_block>>>(
-      model.mhd_d, model.grid_local.i_total, model.grid_local.j_total,
-      model.grid_local.k_total);
-  CUDA_CHECK(cudaGetLastError());
-  CUDA_CHECK(cudaDeviceSynchronize());
-
-  cudaDeviceSynchronize();
-  model.mhd_d.qq.copy_to_host(model.mhd.qq);
-
-  for (int i = 0; i < model.grid_local.i_total; ++i) {
-    for (int j = 0; j < model.grid_local.j_total; ++j) {
-      for (int k = 0; k < model.grid_local.k_total; ++k) {
-        std::cout << model.mhd.qq.ro(i, j, k) << " " << i << " " << j << " " << k
-                  << std::endl;
-      }
-    }
-  }
-
-  model.mhd_d.qq.free();
-
   return 0;
 }


### PR DESCRIPTION
- marginのやり取りのみのMPIを実装
- 1MPI/1GPUの設定としている
  - ノードを跨ぐことを意識していない
  - `mpi_manager.hpp`で`cudaSetDevice(myrank)`としている
  - 複数ノードを使うときは変更が必要
- cuda_testで通信のテスト
- 現状2GPUまでしか使えないので、隣とのやり取りのチェックのみ