### PR TITLE
1D shock tubeのdefaultのconfig.yamlの場所。現在存在しないconfig.yamlを指定していたので、config/config_x.yamlを指定しました。1D shock tubeを実行しようとしていきなりつまずくのを避けるためです。

### DIFF
--- a/demo/hd1d_shock_tube/src/main.cpp
+++ b/demo/hd1d_shock_tube/src/main.cpp
@@ -165,6 +165,7 @@ int main(int argc, char **argv) {
 
   // Read configuration file
   auto config_path = parse_config_filepath(argc, argv);
+  // by default, x-direction shock tube config is loaded.
   Config config(config_path.value_or("./config/config_x.yaml"));
 
   // Run simulation

--- a/demo/hd1d_shock_tube/src/main.cpp
+++ b/demo/hd1d_shock_tube/src/main.cpp
@@ -165,7 +165,7 @@ int main(int argc, char **argv) {
 
   // Read configuration file
   auto config_path = parse_config_filepath(argc, argv);
-  Config config(config_path.value_or("./config.yaml"));
+  Config config(config_path.value_or("./config/config_x.yaml"));
 
   // Run simulation
   Model model(config);

--- a/demo/mhd1d_shock_tube/src/main.cpp
+++ b/demo/mhd1d_shock_tube/src/main.cpp
@@ -178,6 +178,7 @@ int main(int argc, char **argv) {
 
   // Read configuration file
   auto config_path = parse_config_filepath(argc, argv);
+  // by default, x-direction shock tube config is loaded.
   Config config(config_path.value_or("./config/config_x.yaml"));
 
   // Run simulation

--- a/demo/mhd1d_shock_tube/src/main.cpp
+++ b/demo/mhd1d_shock_tube/src/main.cpp
@@ -178,7 +178,7 @@ int main(int argc, char **argv) {
 
   // Read configuration file
   auto config_path = parse_config_filepath(argc, argv);
-  Config config(config_path.value_or("./config.yaml"));
+  Config config(config_path.value_or("./config/config_x.yaml"));
 
   // Run simulation
   Model model(config);


### PR DESCRIPTION
1D shock tubeのdefaultのconfig.yamlの場所。現在存在しないconfig.yamlを指定していたので、config/config_x.yamlを指定しました。1D shock tubeを実行しようとしていきなりつまずくのを避けるためです。