### PR TITLE
一般化状態方程式への対応

### DIFF
--- a/demo/mhd2d_vortex/src/main.cpp
+++ b/demo/mhd2d_vortex/src/main.cpp
@@ -25,7 +25,7 @@ struct InitialCondition {
       for (int j = 0; j < grid.j_total; ++j) {
         for (int i = 0; i < grid.i_total; ++i) {
           qq.ro(i, j, k) = 1.0;
-          qq.ei(i, j, k) = eos.roprtoei(qq.ro(i, j, k), pr);
+          qq.ei(i, j, k) = pr / (eos.gm - 1.0) / qq.ro(i, j, k);
           qq.vx(i, j, k) = -v0 * util::sin(2.0 * pi<Real> * grid.y[j]);
           qq.vy(i, j, k) = +v0 * util::sin(2.0 * pi<Real> * grid.x[i]);
           qq.vz(i, j, k) = 0.0;

--- a/miso/include/miso/array2d.hpp
+++ b/miso/include/miso/array2d.hpp
@@ -111,7 +111,7 @@ public:
 
   /// @brief Return the array extent in each dimension.
   __host__ __device__ int extent(int dim) const noexcept {
-    assert(dim >= 0 && dim < 3);
+    assert(dim >= 0 && dim < 2);
     return shape_[dim];
   }
 

--- a/miso/include/miso/array2d.hpp
+++ b/miso/include/miso/array2d.hpp
@@ -1,0 +1,301 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <limits>
+
+#include "backend.hpp"
+#include "cuda_compat.hpp"
+#ifdef __CUDACC__
+#include "cuda_util.cuh"
+#endif  // __CUDACC__
+
+namespace miso {
+
+/// @brief 2D Array in general execution/memory space.
+template <typename T, typename Backend = backend::Host> class Array2D;
+
+/// @brief Lightweight non-owning view of 2D array data.
+template <typename T> class Array2DView {
+private:
+  T *data_ = nullptr;
+  int shape_[2] = {-1, -1};
+
+  // Always constructed from Array2D
+  // to ensure that the array size is within the numeric limits of int.
+  template <typename, typename> friend class Array2D;
+  Array2DView(T *data, int nx0, int nx1) noexcept
+      : data_(data), shape_{nx0, nx1} {}
+
+public:
+  /// @brief Return pointer to the data.
+  __host__ __device__ T *data() noexcept { return data_; }
+
+  /// @brief Return const pointer to the data.
+  __host__ __device__ const T *data() const noexcept { return data_; }
+
+  /// @brief Return the array extent in each dimension.
+  __host__ __device__ int extent(int dim) const noexcept {
+    assert(dim >= 0 && dim < 2);
+    return shape_[dim];
+  }
+
+  // The shape() method is not implemented in Array2DView
+  // as returning shape from a __host__ __device__ interface is awkward.
+  // Use extent() instead.
+
+  /// @brief Return the total size of the array.
+  __host__ __device__ int size() const noexcept { return shape_[0] * shape_[1]; }
+
+  /// @brief Return reference to the element at the given indices.
+  __host__ __device__ T &operator()(int i0, int i1) const noexcept {
+    assert(data_);
+    assert(i0 >= 0 && i0 < shape_[0]);
+    assert(i1 >= 0 && i1 < shape_[1]);
+    return data_[i0 * shape_[1] + i1];
+  }
+
+  /// @brief Return reference to the element at the given linear index.
+  __host__ __device__ T &operator[](int idx) const noexcept {
+    assert(data_);
+    assert(idx >= 0 && idx < size());
+    return data_[idx];
+  }
+
+  // Allow copy semantics
+  __host__ __device__ Array2DView(const Array2DView &) noexcept = default;
+  __host__ __device__ Array2DView &
+  operator=(const Array2DView &) noexcept = default;
+};
+
+/// @brief 2D Array in host memory.
+template <typename T> class Array2D<T, backend::Host> {
+private:
+  T *data_ = nullptr;
+  std::array<int, 2> shape_ = {-1, -1};
+
+public:
+  Array2D(int nx0, int nx1) : shape_{nx0, nx1} {
+    assert(shape_[0] > 0 && shape_[1] > 0);
+    const std::size_t array_size =
+        static_cast<size_t>(shape_[0]) * static_cast<size_t>(shape_[1]);
+    assert(array_size <= static_cast<size_t>(std::numeric_limits<int>::max()));
+    data_ = new T[array_size];
+  }
+
+  ~Array2D() { delete[] data_; }
+
+  /// @brief Return a lightweight view of the array.
+  Array2DView<T> view() noexcept {
+    assert(data_);
+    assert(shape_[0] > 0 && shape_[1] > 0);
+    return Array2DView<T>(data_, shape_[0], shape_[1]);
+  }
+
+  /// @brief Return a constant lightweight view of the array.
+  Array2DView<const T> view() const noexcept {
+    assert(data_);
+    assert(shape_[0] > 0 && shape_[1] > 0);
+    return Array2DView<const T>(data_, shape_[0], shape_[1]);
+  }
+
+  /// @brief Return a constant lightweight view of the array.
+  Array2DView<const T> const_view() const noexcept { return view(); }
+
+  /// @brief Return pointer to the data.
+  T *data() noexcept { return data_; }
+
+  /// @brief Return const pointer to the data.
+  const T *data() const noexcept { return data_; }
+
+  /// @brief Return the array extent in each dimension.
+  __host__ __device__ int extent(int dim) const noexcept {
+    assert(dim >= 0 && dim < 3);
+    return shape_[dim];
+  }
+
+  /// @brief Return the shape of the array in the given axis.
+  std::array<int, 2> shape() const noexcept { return shape_; }
+
+  /// @brief Return the total size of the array.
+  int size() const noexcept { return shape_[0] * shape_[1]; }
+
+  /// @brief Return reference to the element at the given indices.
+  T &operator()(int i0, int i1) const noexcept {
+    assert(data_);
+    assert(i0 >= 0 && i0 < shape_[0]);
+    assert(i1 >= 0 && i1 < shape_[1]);
+    return data_[i0 * shape_[1] + i1];
+  }
+
+  /// @brief Return reference to the element at the given linear index.
+  T &operator[](int idx) const noexcept {
+    assert(data_);
+    assert(idx >= 0 && idx < size());
+    return data_[idx];
+  }
+
+  /// @brief Copy data from another Array2D in host memory.
+  void copy_from(const Array2D<T, backend::Host> &other) {
+    assert(other.data() && data());
+    assert(other.shape() == shape());
+    std::copy(other.data(), other.data() + other.size(), data());
+  }
+
+#ifdef __CUDACC__
+  /// @brief Copy data from another Array2D in CUDA memory.
+  void copy_from(const Array2D<T, backend::CUDA> &other) {
+    assert(other.data() && data());
+    assert(other.shape() == shape());
+    MISO_CUDA_CHECK(cudaMemcpy(data(), other.data(), sizeof(T) * other.size(),
+                               cudaMemcpyDeviceToHost));
+  }
+
+  /// @brief Copy data from another Array2D in CUDA memory (async).
+  /// @details The caller is responsible for synchronizing the stream.
+  void copy_from(const Array2D<T, backend::CUDA> &other, cudaStream_t stream) {
+    assert(other.data() && data());
+    assert(other.shape() == shape());
+    MISO_CUDA_CHECK(cudaMemcpyAsync(data(), other.data(),
+                                    sizeof(T) * other.size(),
+                                    cudaMemcpyDeviceToHost, stream));
+  }
+#endif  // __CUDACC__
+
+  // Prohibit copy semantics
+  Array2D(const Array2D &) = delete;
+  Array2D &operator=(const Array2D &) = delete;
+
+  // Allow move semantics (allow uninitialized state)
+  Array2D(Array2D &&other) noexcept : data_(other.data_), shape_(other.shape_) {
+    other.data_ = nullptr;
+    other.shape_ = std::array<int, 2>{-1, -1};
+  }
+  Array2D &operator=(Array2D &&other) noexcept {
+    if (this != &other) {
+      delete[] data_;
+      data_ = other.data_;
+      shape_ = other.shape_;
+      other.data_ = nullptr;
+      other.shape_ = std::array<int, 2>{-1, -1};
+    }
+    return *this;
+  }
+};
+
+#ifdef __CUDACC__
+/// @brief 2D Array in CUDA device memory.
+template <typename T> class Array2D<T, backend::CUDA> {
+private:
+  T *data_ = nullptr;
+  std::array<int, 2> shape_ = {-1, -1};
+
+public:
+  Array2D(int nx0, int nx1) : shape_{nx0, nx1} {
+    assert(shape_[0] > 0 && shape_[1] > 0);
+    const std::size_t array_size =
+        static_cast<size_t>(shape_[0]) * static_cast<size_t>(shape_[1]);
+    assert(array_size <= static_cast<size_t>(std::numeric_limits<int>::max()));
+    MISO_CUDA_CHECK(cudaMalloc(&data_, sizeof(T) * array_size));
+  }
+
+  ~Array2D() {
+    if (data_)
+      cudaFree(data_);
+    data_ = nullptr;
+  }
+
+  /// @brief Return a lightweight view of the array.
+  Array2DView<T> view() noexcept {
+    assert(data_);
+    assert(shape_[0] > 0 && shape_[1] > 0);
+    return Array2DView<T>(data_, shape_[0], shape_[1]);
+  }
+
+  /// @brief Return a constant lightweight view of the array.
+  Array2DView<const T> view() const noexcept {
+    assert(data_);
+    assert(shape_[0] > 0 && shape_[1] > 0);
+    return Array2DView<const T>(data_, shape_[0], shape_[1]);
+  }
+
+  /// @brief Return a constant lightweight view of the array.
+  Array2DView<const T> const_view() const noexcept { return view(); }
+
+  /// @brief Return pointer to the data.
+  T *data() noexcept { return data_; }
+
+  /// @brief Return const pointer to the data.
+  const T *data() const noexcept { return data_; }
+
+  /// @brief Return the array extent in each dimension.
+  __host__ __device__ int extent(int dim) const noexcept {
+    assert(dim >= 0 && dim < 2);
+    return shape_[dim];
+  }
+
+  /// @brief Return the shape of the array in the given axis.
+  std::array<int, 2> shape() const noexcept { return shape_; }
+
+  /// @brief Return the total size of the array.
+  int size() const noexcept { return shape_[0] * shape_[1]; }
+
+  /// @brief Copy data from another Array2D in host memory.
+  void copy_from(const Array2D<T, backend::Host> &other) {
+    assert(other.data() && data());
+    assert(other.shape() == shape());
+    MISO_CUDA_CHECK(cudaMemcpy(data(), other.data(), sizeof(T) * size(),
+                               cudaMemcpyHostToDevice));
+  }
+
+  /// @brief Copy data from another Array2D in CUDA memory.
+  void copy_from(const Array2D<T, backend::CUDA> &other) {
+    assert(other.data() && data());
+    assert(other.shape() == shape());
+    MISO_CUDA_CHECK(cudaMemcpy(data(), other.data(), sizeof(T) * size(),
+                               cudaMemcpyDeviceToDevice));
+  }
+
+  /// @brief Copy data from another Array2D in host memory (async).
+  /// @details The caller is responsible for synchronizing the stream.
+  void copy_from(const Array2D<T, backend::Host> &other, cudaStream_t stream) {
+    assert(other.data() && data());
+    assert(other.shape() == shape());
+    MISO_CUDA_CHECK(cudaMemcpyAsync(data(), other.data(), sizeof(T) * size(),
+                                    cudaMemcpyHostToDevice, stream));
+  }
+
+  /// @brief Copy data from another Array2D in CUDA memory (async).
+  /// @details The caller is responsible for synchronizing the stream.
+  void copy_from(const Array2D<T, backend::CUDA> &other, cudaStream_t stream) {
+    assert(other.data() && data());
+    assert(other.shape() == shape());
+    MISO_CUDA_CHECK(cudaMemcpyAsync(data(), other.data(), sizeof(T) * size(),
+                                    cudaMemcpyDeviceToDevice, stream));
+  }
+
+  // Prohibit copy semantics
+  Array2D(const Array2D &) = delete;
+  Array2D &operator=(const Array2D &) = delete;
+
+  // Allow move semantics (allow uninitialized state)
+  Array2D(Array2D &&other) noexcept : data_(other.data_), shape_(other.shape_) {
+    other.data_ = nullptr;
+    other.shape_ = std::array<int, 2>{-1, -1};
+  }
+  Array2D &operator=(Array2D &&other) noexcept {
+    if (this != &other) {
+      if (data_)
+        cudaFree(data_);
+      data_ = other.data_;
+      shape_ = other.shape_;
+      other.data_ = nullptr;
+      other.shape_ = std::array<int, 2>{-1, -1};
+    }
+    return *this;
+  }
+};
+#endif  // __CUDACC__
+
+}  // namespace miso

--- a/miso/include/miso/eos.hpp
+++ b/miso/include/miso/eos.hpp
@@ -1,13 +1,14 @@
 #pragma once
 
 #include "config.hpp"
+#include "execution.hpp"
+#include "mhd.hpp"
 #include "utility.hpp"
 
 namespace miso {
 namespace eos {
 
 /// @brief Ideal gas equation of state
-/// @details This class needs to be trivially copyable for device transfer.
 template <typename Real> struct IdealEOS {
   /// @brief Ratio of specific heats (gamma)
   Real gm;
@@ -18,19 +19,27 @@ template <typename Real> struct IdealEOS {
   /// @brief Construct the EOS from the specific heat ratio (gamma)
   explicit IdealEOS(Real gm) : gm(gm) {}
 
-  /// @brief Compute gas pressure from mass density and specific internal energy
-  __host__ __device__ inline Real roeitopr(Real ro, Real ei) const noexcept {
-    return (gm - 1.0) * ro * ei;
+  /// @brief Compute gas pressure from primitive MHD fields.
+  /// @note The signature must not be changed as it is called inside mhd::MHD.
+  template <typename Backend>
+  void gas_pressure(Backend btag, mhd::FieldsView<const Real> qq,
+                    Array3DView<Real> pr) const {
+    Range1D range{0, qq.size()};
+    for_each(
+        btag, range,
+        MISO_LAMBDA(int i) { pr[i] = (gm - Real(1)) * qq.ro[i] * qq.ei[i]; });
   }
 
-  /// @brief Compute specific internal energy from mass density and gas pressure
-  __host__ __device__ inline Real roprtoei(Real ro, Real pr) const noexcept {
-    return pr / (gm - 1.0) / ro;
-  }
-
-  /// @brief Compute adiabatic speed of sound from mass density and specific internal energy
-  __host__ __device__ inline Real roeitocs(Real /*ro*/, Real ei) const noexcept {
-    return util::sqrt(gm * (gm - 1.0) * ei);
+  /// @brief Compute speed of sound from primitive MHD fields.
+  /// @note The signature must not be changed as it is called inside mhd::MHD.
+  template <typename Backend>
+  void sound_speed(Backend btag, mhd::FieldsView<const Real> qq,
+                   Array3DView<Real> cs) const {
+    Range1D range{0, qq.size()};
+    for_each(
+        btag, range, MISO_LAMBDA(int i) {
+          cs[i] = util::sqrt(gm * (gm - Real(1)) * qq.ei[i]);
+        });
   }
 };
 

--- a/miso/include/miso/eos.hpp
+++ b/miso/include/miso/eos.hpp
@@ -29,7 +29,7 @@ template <typename Real> struct IdealEOS {
   }
 
   /// @brief Compute adiabatic speed of sound from mass density and specific internal energy
-  __host__ __device__ inline Real roeitocs(Real, Real ei) const noexcept {
+  __host__ __device__ inline Real roeitocs(Real /*ro*/, Real ei) const noexcept {
     return util::sqrt(gm * (gm - 1.0) * ei);
   }
 };

--- a/miso/include/miso/eos.hpp
+++ b/miso/include/miso/eos.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "config.hpp"
+#include "utility.hpp"
 
 namespace miso {
 namespace eos {
@@ -11,9 +12,11 @@ template <typename Real> struct IdealEOS {
   /// @brief Ratio of specific heats (gamma)
   Real gm;
 
-  /// @brief Constructor
-  /// @param gm_ Ratio of specific heats (gamma)
+  /// @brief Construct the EOS from the configuration file
   explicit IdealEOS(const Config &config) : gm(config["eos"]["gm"].as<Real>()) {}
+
+  /// @brief Construct the EOS from the specific heat ratio (gamma)
+  explicit IdealEOS(Real gm) : gm(gm) {}
 
   /// @brief Compute gas pressure from mass density and specific internal energy
   __host__ __device__ inline Real roeitopr(Real ro, Real ei) const noexcept {
@@ -23,6 +26,11 @@ template <typename Real> struct IdealEOS {
   /// @brief Compute specific internal energy from mass density and gas pressure
   __host__ __device__ inline Real roprtoei(Real ro, Real pr) const noexcept {
     return pr / (gm - 1.0) / ro;
+  }
+
+  /// @brief Compute adiabatic speed of sound from mass density and specific internal energy
+  __host__ __device__ inline Real roeitocs(Real, Real ei) const noexcept {
+    return util::sqrt(gm * (gm - 1.0) * ei);
   }
 };
 

--- a/miso/include/miso/mhd_artificial_viscosity_cuda.cuh
+++ b/miso/include/miso/mhd_artificial_viscosity_cuda.cuh
@@ -15,12 +15,10 @@ namespace artificial_viscosity {
 using miso::limiter::dqq_eval;
 using miso::limiter::flux_core;
 
-template <typename Real, typename EOS>
-__global__ void characteristic_velocity_eval_kernel(Array3DView<Real> cc_d,
-                                                    FieldsView<const Real> qq,
-                                                    GridView<Real> grid,
-                                                    Real cs_fac, Real ca_fac,
-                                                    Real vv_fac, EOS eos) {
+template <typename Real>
+__global__ void characteristic_velocity_eval_kernel(
+    Array3DView<Real> cc_d, FieldsView<const Real> qq, Array3DView<const Real> cs,
+    GridView<const Real> grid, Real cs_fac, Real ca_fac, Real vv_fac) {
 
   int i = blockIdx.x * blockDim.x + threadIdx.x;
   int j = blockIdx.y * blockDim.y + threadIdx.y;
@@ -28,7 +26,6 @@ __global__ void characteristic_velocity_eval_kernel(Array3DView<Real> cc_d,
 
   if (i <= grid.i_total - 1 && j <= grid.j_total - 1 && k <= grid.k_total - 1) {
     // clang-format off
-    Real cs = eos.roeitocs(qq.ro(i, j, k), qq.ei(i, j, k));
     Real vv = util::sqrt(qq.vx(i, j, k) * qq.vx(i, j, k) +
                         qq.vy(i, j, k) * qq.vy(i, j, k) +
                         qq.vz(i, j, k) * qq.vz(i, j, k));
@@ -37,7 +34,7 @@ __global__ void characteristic_velocity_eval_kernel(Array3DView<Real> cc_d,
                          qq.bz(i, j, k) * qq.bz(i, j, k)) /
                          qq.ro(i, j, k) * pii4<Real>);
     // clang-format on
-    cc_d(i, j, k) = cs * cs_fac + vv * vv_fac + ca * ca_fac;
+    cc_d(i, j, k) = cs(i, j, k) * cs_fac + vv * vv_fac + ca * ca_fac;
   }
 }
 
@@ -461,6 +458,8 @@ template <typename Real> struct ArtificialViscosity {
 
   /// @brief Characteristic velocity cs_fac*cs + ca_fac*ca + vv_fac*vv
   Array3D<Real, backend::CUDA> cc;
+  /// @brief Speed of sound
+  Array3D<Real, backend::CUDA> cs;
   /// @brief Parameters for generalized minmod limiter
   Real ep;
   /// @brief Parameters for amplitude of artificial viscosity flux
@@ -476,7 +475,8 @@ template <typename Real> struct ArtificialViscosity {
   ArtificialViscosity(Config &config, Grid<Real, backend::CUDA> &grid,
                       cuda::KernelShape3D &cu_shape)
       : grid(grid), cu_shape(cu_shape),
-        cc(grid.i_total, grid.j_total, grid.k_total) {
+        cc(grid.i_total, grid.j_total, grid.k_total),
+        cs(grid.i_total, grid.j_total, grid.k_total) {
     ep = config["mhd"]["artificial_viscosity"]["ep"].as<Real>();
     fh = config["mhd"]["artificial_viscosity"]["fh"].as<Real>();
     cs_fac = config["mhd"]["artificial_viscosity"]["cs_fac"].as<Real>();
@@ -490,9 +490,11 @@ template <typename Real> struct ArtificialViscosity {
   template <typename EOS>
   void characteristic_velocity_eval(const Fields<Real, backend::CUDA> &qq,
                                     const EOS &eos) {
-    artificial_viscosity::characteristic_velocity_eval_kernel<Real, EOS>
+    eos.sound_speed(backend::CUDA{}, qq.const_view(), cs.view());
+    artificial_viscosity::characteristic_velocity_eval_kernel<Real>
         <<<cu_shape.grid_dim, cu_shape.block_dim>>>(
-            cc.view(), qq.view(), grid.view(), cs_fac, ca_fac, vv_fac, eos);
+            cc.view(), qq.const_view(), cs.const_view(), grid.const_view(),
+            cs_fac, ca_fac, vv_fac);
   }
 
   void update(Fields<Real, backend::CUDA> &qq,

--- a/miso/include/miso/mhd_artificial_viscosity_cuda.cuh
+++ b/miso/include/miso/mhd_artificial_viscosity_cuda.cuh
@@ -15,12 +15,12 @@ namespace artificial_viscosity {
 using miso::limiter::dqq_eval;
 using miso::limiter::flux_core;
 
-template <typename Real>
+template <typename Real, typename EOS>
 __global__ void characteristic_velocity_eval_kernel(Array3DView<Real> cc_d,
                                                     FieldsView<const Real> qq,
                                                     GridView<Real> grid,
-                                                    Real eos_gm, Real cs_fac,
-                                                    Real ca_fac, Real vv_fac) {
+                                                    Real cs_fac, Real ca_fac,
+                                                    Real vv_fac, EOS eos) {
 
   int i = blockIdx.x * blockDim.x + threadIdx.x;
   int j = blockIdx.y * blockDim.y + threadIdx.y;
@@ -28,7 +28,7 @@ __global__ void characteristic_velocity_eval_kernel(Array3DView<Real> cc_d,
 
   if (i <= grid.i_total - 1 && j <= grid.j_total - 1 && k <= grid.k_total - 1) {
     // clang-format off
-    Real cs = util::sqrt(eos_gm * (eos_gm - 1.0) * qq.ei(i, j, k));
+    Real cs = eos.roeitocs(qq.ro(i, j, k), qq.ei(i, j, k));
     Real vv = util::sqrt(qq.vx(i, j, k) * qq.vx(i, j, k) +
                         qq.vy(i, j, k) * qq.vy(i, j, k) +
                         qq.vz(i, j, k) * qq.vz(i, j, k));
@@ -490,9 +490,9 @@ template <typename Real> struct ArtificialViscosity {
   template <typename EOS>
   void characteristic_velocity_eval(const Fields<Real, backend::CUDA> &qq,
                                     const EOS &eos) {
-    artificial_viscosity::characteristic_velocity_eval_kernel<Real>
+    artificial_viscosity::characteristic_velocity_eval_kernel<Real, EOS>
         <<<cu_shape.grid_dim, cu_shape.block_dim>>>(
-            cc.view(), qq.view(), grid.view(), eos.gm, cs_fac, ca_fac, vv_fac);
+            cc.view(), qq.view(), grid.view(), cs_fac, ca_fac, vv_fac, eos);
   }
 
   void update(Fields<Real, backend::CUDA> &qq,

--- a/miso/include/miso/mhd_artificial_viscosity_host.hpp
+++ b/miso/include/miso/mhd_artificial_viscosity_host.hpp
@@ -50,14 +50,14 @@ template <typename Real> struct ArtificialViscosity {
       for (int j = 0; j < grid.j_total; ++j) {
         for (int k = 0; k < grid.k_total; ++k) {
           // cs: sound speed, vv: fluid velocity, ca: Alfvén speed
-          Real cs = std::sqrt(eos.gm * (eos.gm - 1.0) * qq.ei(i, j, k));
-          Real vv = std::sqrt(+qq.vx(i, j, k) * qq.vx(i, j, k) +
-                              qq.vy(i, j, k) * qq.vy(i, j, k) +
-                              qq.vz(i, j, k) * qq.vz(i, j, k));
-          Real ca = std::sqrt((+qq.bx(i, j, k) * qq.bx(i, j, k) +
-                               qq.by(i, j, k) * qq.by(i, j, k) +
-                               qq.bz(i, j, k) * qq.bz(i, j, k)) /
-                              qq.ro(i, j, k) * pii4<Real>);
+          Real cs = eos.roeitocs(qq.ro(i, j, k), qq.ei(i, j, k));
+          Real vv = util::sqrt(qq.vx(i, j, k) * qq.vx(i, j, k) +
+                               qq.vy(i, j, k) * qq.vy(i, j, k) +
+                               qq.vz(i, j, k) * qq.vz(i, j, k));
+          Real ca = util::sqrt((qq.bx(i, j, k) * qq.bx(i, j, k) +
+                                qq.by(i, j, k) * qq.by(i, j, k) +
+                                qq.bz(i, j, k) * qq.bz(i, j, k)) /
+                               qq.ro(i, j, k) * pii4<Real>);
           cc(i, j, k) = cs * cs_fac + vv * vv_fac + ca * ca_fac;
         }
       }

--- a/miso/include/miso/mhd_artificial_viscosity_host.hpp
+++ b/miso/include/miso/mhd_artificial_viscosity_host.hpp
@@ -20,6 +20,8 @@ template <typename Real> struct ArtificialViscosity {
 
   /// @brief Characteristic velocity cs_fac*cs + ca_fac*ca + vv_fac*vv
   Array3D<Real, backend::Host> cc;
+  /// @brief Speed of sound
+  Array3D<Real, backend::Host> cs;
   /// @brief Parameters for generalized minmod limiter
   Real ep;
   /// @brief Parameters for amplitude of artificial viscosity flux
@@ -33,7 +35,8 @@ template <typename Real> struct ArtificialViscosity {
 
   /// @brief Constructor for ArtificialViscosity
   ArtificialViscosity(Config &config, Grid<Real, backend::Host> &grid)
-      : grid(grid), cc(grid.i_total, grid.j_total, grid.k_total) {
+      : grid(grid), cc(grid.i_total, grid.j_total, grid.k_total),
+        cs(grid.i_total, grid.j_total, grid.k_total) {
     ep = config["mhd"]["artificial_viscosity"]["ep"].as<Real>();
     fh = config["mhd"]["artificial_viscosity"]["fh"].as<Real>();
     cs_fac = config["mhd"]["artificial_viscosity"]["cs_fac"].as<Real>();
@@ -46,11 +49,11 @@ template <typename Real> struct ArtificialViscosity {
   /// @brief Evaluate the characteristic velocity
   template <typename EOS>
   void characteristic_velocity_eval(const Fields<Real> &qq, const EOS &eos) {
+    eos.sound_speed(backend::Host{}, qq.const_view(), cs.view());
     for (int i = 0; i < grid.i_total; ++i) {
       for (int j = 0; j < grid.j_total; ++j) {
         for (int k = 0; k < grid.k_total; ++k) {
           // cs: sound speed, vv: fluid velocity, ca: Alfvén speed
-          Real cs = eos.roeitocs(qq.ro(i, j, k), qq.ei(i, j, k));
           Real vv = util::sqrt(qq.vx(i, j, k) * qq.vx(i, j, k) +
                                qq.vy(i, j, k) * qq.vy(i, j, k) +
                                qq.vz(i, j, k) * qq.vz(i, j, k));
@@ -58,7 +61,7 @@ template <typename Real> struct ArtificialViscosity {
                                 qq.by(i, j, k) * qq.by(i, j, k) +
                                 qq.bz(i, j, k) * qq.bz(i, j, k)) /
                                qq.ro(i, j, k) * pii4<Real>);
-          cc(i, j, k) = cs * cs_fac + vv * vv_fac + ca * ca_fac;
+          cc(i, j, k) = cs(i, j, k) * cs_fac + vv * vv_fac + ca * ca_fac;
         }
       }
     }

--- a/miso/include/miso/mhd_integrator_cuda.cuh
+++ b/miso/include/miso/mhd_integrator_cuda.cuh
@@ -13,11 +13,11 @@
 namespace miso {
 namespace mhd {
 
-template <typename Real>
+template <typename Real, typename EOS>
 __global__ void pr_bb_ht_vb_kernel(FieldsView<const Real> qq_argm,
                                    Array3DView<Real> pr, Array3DView<Real> bb,
                                    Array3DView<Real> ht, Array3DView<Real> vb,
-                                   GridView<const Real> grid, Real eos_gm) {
+                                   GridView<const Real> grid, EOS eos) {
   int i = blockIdx.x * blockDim.x + threadIdx.x;
   int j = blockIdx.y * blockDim.y + threadIdx.y;
   int k = blockIdx.z * blockDim.z + threadIdx.z;
@@ -27,7 +27,7 @@ __global__ void pr_bb_ht_vb_kernel(FieldsView<const Real> qq_argm,
     return;
 
   // gas pressure
-  pr(i, j, k) = qq_argm.ro(i, j, k) * qq_argm.ei(i, j, k) * (eos_gm - 1.0);
+  pr(i, j, k) = eos.roeitopr(qq_argm.ro(i, j, k), qq_argm.ei(i, j, k));
   // squared magnetic strength
   bb(i, j, k) = qq_argm.bx(i, j, k) * qq_argm.bx(i, j, k) +
                 qq_argm.by(i, j, k) * qq_argm.by(i, j, k) +
@@ -344,9 +344,8 @@ template <typename Real> struct Integrator<Real, backend::CUDA> {
                   Fields<Real, backend::CUDA> &qq_rslt) {
     const auto &cgrid = grid.const_view();
 
-    pr_bb_ht_vb_kernel<Real><<<cu_shape.grid_dim, cu_shape.block_dim>>>(
-        qq_argm.view(), pr.view(), bb.view(), ht.view(), vb.view(), cgrid,
-        eos.gm);
+    pr_bb_ht_vb_kernel<Real, EOS><<<cu_shape.grid_dim, cu_shape.block_dim>>>(
+        qq_argm.view(), pr.view(), bb.view(), ht.view(), vb.view(), cgrid, eos);
     MISO_CUDA_CHECK(cudaGetLastError());
 
     update_ro_kernel<Real><<<cu_shape.grid_dim, cu_shape.block_dim>>>(
@@ -455,7 +454,7 @@ template <typename Real> struct Integrator<Real, backend::CUDA> {
                   {grid.j_margin, grid.j_total - grid.j_margin},
                   {grid.k_margin, grid.k_total - grid.k_margin}};
     const auto f = MISO_LAMBDA(int i, int j, int k) {
-      Real cs = util::sqrt(eos.gm * (eos.gm - 1.0) * qq_v.ei(i, j, k));
+      Real cs = eos.roeitocs(qq_v.ro(i, j, k), qq_v.ei(i, j, k));
       Real vv = util::sqrt(qq_v.vx(i, j, k) * qq_v.vx(i, j, k) +
                            qq_v.vy(i, j, k) * qq_v.vy(i, j, k) +
                            qq_v.vz(i, j, k) * qq_v.vz(i, j, k));

--- a/miso/include/miso/mhd_integrator_cuda.cuh
+++ b/miso/include/miso/mhd_integrator_cuda.cuh
@@ -13,11 +13,11 @@
 namespace miso {
 namespace mhd {
 
-template <typename Real, typename EOS>
-__global__ void pr_bb_ht_vb_kernel(FieldsView<const Real> qq_argm,
-                                   Array3DView<Real> pr, Array3DView<Real> bb,
-                                   Array3DView<Real> ht, Array3DView<Real> vb,
-                                   GridView<const Real> grid, EOS eos) {
+template <typename Real>
+__global__ void bb_ht_vb_kernel(FieldsView<const Real> qq_argm,
+                                Array3DView<Real> pr, Array3DView<Real> bb,
+                                Array3DView<Real> ht, Array3DView<Real> vb,
+                                GridView<const Real> grid) {
   int i = blockIdx.x * blockDim.x + threadIdx.x;
   int j = blockIdx.y * blockDim.y + threadIdx.y;
   int k = blockIdx.z * blockDim.z + threadIdx.z;
@@ -26,8 +26,6 @@ __global__ void pr_bb_ht_vb_kernel(FieldsView<const Real> qq_argm,
       k >= grid.k_total)
     return;
 
-  // gas pressure
-  pr(i, j, k) = eos.roeitopr(qq_argm.ro(i, j, k), qq_argm.ei(i, j, k));
   // squared magnetic strength
   bb(i, j, k) = qq_argm.bx(i, j, k) * qq_argm.bx(i, j, k) +
                 qq_argm.by(i, j, k) * qq_argm.by(i, j, k) +
@@ -315,6 +313,7 @@ template <typename Real> struct Integrator<Real, backend::CUDA> {
   Array3D<Real, backend::CUDA> ht;
   /// @brief inner product of velocity and magnetic field vx*bx + vy*by + vz*bz
   Array3D<Real, backend::CUDA> vb;
+  Array3D<Real, backend::CUDA> cs;
 
   /// @brief CFL number
   Real cfl_number;
@@ -332,7 +331,8 @@ template <typename Real> struct Integrator<Real, backend::CUDA> {
         pr(grid.i_total, grid.j_total, grid.k_total),
         bb(grid.i_total, grid.j_total, grid.k_total),
         ht(grid.i_total, grid.j_total, grid.k_total),
-        vb(grid.i_total, grid.j_total, grid.k_total) {
+        vb(grid.i_total, grid.j_total, grid.k_total),
+        cs(grid.i_total, grid.j_total, grid.k_total) {
     cfl_number = config["mhd"]["cfl_number"].as<Real>();
   }
 
@@ -344,8 +344,9 @@ template <typename Real> struct Integrator<Real, backend::CUDA> {
                   Fields<Real, backend::CUDA> &qq_rslt) {
     const auto &cgrid = grid.const_view();
 
-    pr_bb_ht_vb_kernel<Real, EOS><<<cu_shape.grid_dim, cu_shape.block_dim>>>(
-        qq_argm.view(), pr.view(), bb.view(), ht.view(), vb.view(), cgrid, eos);
+    eos.gas_pressure(backend::CUDA{}, qq_argm.const_view(), pr.view());
+    bb_ht_vb_kernel<Real><<<cu_shape.grid_dim, cu_shape.block_dim>>>(
+        qq_argm.view(), pr.view(), bb.view(), ht.view(), vb.view(), cgrid);
     MISO_CUDA_CHECK(cudaGetLastError());
 
     update_ro_kernel<Real><<<cu_shape.grid_dim, cu_shape.block_dim>>>(
@@ -449,12 +450,13 @@ template <typename Real> struct Integrator<Real, backend::CUDA> {
   Real cfl(const Fields<Real, backend::CUDA> &qq, const EOS &eos) {
     auto qq_v = qq.const_view();
     auto grid_v = grid.const_view();
+    auto cs_v = cs.view();
 
+    eos.sound_speed(backend::CUDA{}, qq_v, cs_v);
     Range3D range{{grid.i_margin, grid.i_total - grid.i_margin},
                   {grid.j_margin, grid.j_total - grid.j_margin},
                   {grid.k_margin, grid.k_total - grid.k_margin}};
     const auto f = MISO_LAMBDA(int i, int j, int k) {
-      Real cs = eos.roeitocs(qq_v.ro(i, j, k), qq_v.ei(i, j, k));
       Real vv = util::sqrt(qq_v.vx(i, j, k) * qq_v.vx(i, j, k) +
                            qq_v.vy(i, j, k) * qq_v.vy(i, j, k) +
                            qq_v.vz(i, j, k) * qq_v.vz(i, j, k));
@@ -462,7 +464,7 @@ template <typename Real> struct Integrator<Real, backend::CUDA> {
                             qq_v.by(i, j, k) * qq_v.by(i, j, k) +
                             qq_v.bz(i, j, k) * qq_v.bz(i, j, k)) /
                            qq_v.ro(i, j, k) * pii4<Real>);
-      Real total_vel = (cs + vv + ca);
+      Real total_vel = cs_v(i, j, k) + vv + ca;
       Real dxyz = util::min3(grid_v.dx[i], grid_v.dy[j], grid_v.dz[k]);
       return cfl_number * dxyz / total_vel;
     };

--- a/miso/include/miso/mhd_integrator_host.hpp
+++ b/miso/include/miso/mhd_integrator_host.hpp
@@ -60,7 +60,7 @@ template <typename Real> struct Integrator<Real, backend::Host> {
         for (int k = 0; k < grid.k_total; ++k) {
           // clang-format off
           // gas pressure
-          pr(i, j, k) = qq_argm.ro(i,j,k)*qq_argm.ei(i,j,k)*(eos.gm - 1.0);
+          pr(i,j,k) = eos.roeitopr(qq_argm.ro(i,j,k), qq_argm.ei(i,j,k));
           // squared magnetic strength
           bb(i, j, k) = qq_argm.bx(i,j,k)*qq_argm.bx(i,j,k)
                       + qq_argm.by(i,j,k)*qq_argm.by(i,j,k)
@@ -199,7 +199,7 @@ template <typename Real> struct Integrator<Real, backend::Host> {
               -space_centered_4th(c_by, dyi, i, j, k, 0, grid.js, 0)
               -space_centered_4th(c_bz, dzi, i, j, k, 0, 0, grid.ks)
               )
-          )*std::exp(-dt/tau_divb);
+          )*util::exp(-dt/tau_divb);
 
           // Et: total energy per unit volume
           // ei: is the internal energy per unit mass
@@ -304,21 +304,21 @@ template <typename Real> struct Integrator<Real, backend::Host> {
         for (int k = grid.k_margin; k < grid.k_total - grid.k_margin; ++k) {
           // clang-format off
           // cs: sound speed, vv: fluid velocity, ca: Alfvén speed
-          Real cs = std::sqrt(eos.gm*(eos.gm-1.0)*qq.ei(i,j,k));
-          Real vv = std::sqrt(
+          Real cs = eos.roeitocs(qq.ro(i,j,k), qq.ei(i,j,k));
+          Real vv = util::sqrt(
             + qq.vx(i,j,k)*qq.vx(i,j,k)
             + qq.vy(i,j,k)*qq.vy(i,j,k)
             + qq.vz(i,j,k)*qq.vz(i,j,k)
           );
-          Real ca = std::sqrt( (
+          Real ca = util::sqrt( (
             + qq.bx(i,j,k)*qq.bx(i,j,k)
             + qq.by(i,j,k)*qq.by(i,j,k)
             + qq.bz(i,j,k)*qq.bz(i,j,k)
           )/qq.ro(i,j,k)*pii4<Real>);
 
           Real total_vel = cs + vv + ca;
-          dt = std::min(dt, cfl_number
-            * std::min<Real>({grid.dx[i], grid.dy[j], grid.dz[k]})/total_vel);
+          dt = util::min2(dt, cfl_number
+            * util::min3<Real>(grid.dx[i], grid.dy[j], grid.dz[k])/total_vel);
           // clang-format on
         }
       }

--- a/miso/include/miso/mhd_integrator_host.hpp
+++ b/miso/include/miso/mhd_integrator_host.hpp
@@ -29,6 +29,8 @@ template <typename Real> struct Integrator<Real, backend::Host> {
   Array3D<Real, backend::Host> ht;
   /// @brief inner product of velocity and magnetic field vx*bx + vy*by + vz*bz
   Array3D<Real, backend::Host> vb;
+  /// @brief speed of sound
+  Array3D<Real, backend::Host> cs;
 
   /// @brief CFL number
   Real cfl_number;
@@ -46,7 +48,8 @@ template <typename Real> struct Integrator<Real, backend::Host> {
         artdiff(config, grid), pr(grid.i_total, grid.j_total, grid.k_total),
         bb(grid.i_total, grid.j_total, grid.k_total),
         ht(grid.i_total, grid.j_total, grid.k_total),
-        vb(grid.i_total, grid.j_total, grid.k_total) {
+        vb(grid.i_total, grid.j_total, grid.k_total),
+        cs(grid.i_total, grid.j_total, grid.k_total) {
     cfl_number = config["mhd"]["cfl_number"].as<Real>();
   }
 
@@ -55,12 +58,13 @@ template <typename Real> struct Integrator<Real, backend::Host> {
   void update_sc4(const Real dt, const EOS &eos, const Source &src,
                   const Fields<Real> &qq_orgn, const Fields<Real> &qq_argm,
                   Fields<Real> &qq_rslt) {
+    // gas pressure
+    eos.gas_pressure(backend::Host{}, qq_argm.const_view(), pr.view());
+
     for (int i = 0; i < grid.i_total; ++i) {
       for (int j = 0; j < grid.j_total; ++j) {
         for (int k = 0; k < grid.k_total; ++k) {
           // clang-format off
-          // gas pressure
-          pr(i,j,k) = eos.roeitopr(qq_argm.ro(i,j,k), qq_argm.ei(i,j,k));
           // squared magnetic strength
           bb(i, j, k) = qq_argm.bx(i,j,k)*qq_argm.bx(i,j,k)
                       + qq_argm.by(i,j,k)*qq_argm.by(i,j,k)
@@ -297,26 +301,26 @@ template <typename Real> struct Integrator<Real, backend::Host> {
 
   /// @brief Calculate time spacing based on CFL condition
   template <typename EOS>
-  Real cfl(const Fields<Real, backend::Host> &qq, const EOS &eos) const {
+  Real cfl(const Fields<Real, backend::Host> &qq, const EOS &eos) {
     Real dt = 1.e10;
+    eos.sound_speed(backend::Host{}, qq.const_view(), cs.view());
     for (int i = grid.i_margin; i < grid.i_total - grid.i_margin; ++i) {
       for (int j = grid.j_margin; j < grid.j_total - grid.j_margin; ++j) {
         for (int k = grid.k_margin; k < grid.k_total - grid.k_margin; ++k) {
           // clang-format off
           // cs: sound speed, vv: fluid velocity, ca: Alfvén speed
-          Real cs = eos.roeitocs(qq.ro(i,j,k), qq.ei(i,j,k));
           Real vv = util::sqrt(
             + qq.vx(i,j,k)*qq.vx(i,j,k)
             + qq.vy(i,j,k)*qq.vy(i,j,k)
             + qq.vz(i,j,k)*qq.vz(i,j,k)
           );
-          Real ca = util::sqrt( (
+          Real ca = util::sqrt((
             + qq.bx(i,j,k)*qq.bx(i,j,k)
             + qq.by(i,j,k)*qq.by(i,j,k)
             + qq.bz(i,j,k)*qq.bz(i,j,k)
           )/qq.ro(i,j,k)*pii4<Real>);
 
-          Real total_vel = cs + vv + ca;
+          Real total_vel = cs(i, j, k) + vv + ca;
           dt = util::min2(dt, cfl_number
             * util::min3<Real>(grid.dx[i], grid.dy[j], grid.dz[k])/total_vel);
           // clang-format on

--- a/miso/include/miso/table_interpolator.hpp
+++ b/miso/include/miso/table_interpolator.hpp
@@ -1,0 +1,61 @@
+#pragma once
+#include "array1d.hpp"
+#include "execution.hpp"
+#include "utility.hpp"
+
+namespace miso {
+
+// Interpolate a value at x.
+template <class T>
+__device__ __host__ T interpolate_uniform_table(const T *table, T x0, T dxi, T x,
+                                                int n) noexcept {
+  assert(n > 1);
+  T idx = (x - x0) * dxi;
+  idx = util::clamp<T>(idx, T(0), static_cast<T>(n - 1));
+  int i = util::clamp<int>(static_cast<int>(idx), 0, n - 2);
+  T t = idx - static_cast<T>(i);
+  return (T(1) - t) * table[i] + t * table[i + 1];
+}
+
+/// @brief Interpolator for 1D (x) table in the uniform grid.
+/// @details The table is assumed to be sorted in ascending order of x.
+/// The table is assumed to be uniformly spaced, i.e., x[i] = x0 + i * dx.
+/// Value is linearly interpolated between the two nearest table entries.
+/// If x is out of the table range, the nearest table value is returned.
+template <class T, class Backend> class UniformTableInterpolator1D {
+  Array1DView<T> table_;
+  T x0_, x1_, dx_, dxi_;
+
+public:
+  /// @brief Construct the interpolator from the table and grid parameters.
+  UniformTableInterpolator1D(const Array1DView<T> &table, T x0, T x1)
+      : table_(table), x0_(x0), x1_(x1),
+        dx_((x1 - x0) / static_cast<T>(table.size() - 1)),
+        dxi_(static_cast<T>(table.size() - 1) / (x1 - x0)) {}
+
+  /// @brief Interpolate values at the array of x.
+  T interpolate(T x) const noexcept {
+    return interpolate_uniform_table(table_.data(), x0_, dxi_, x, table_.size());
+  }
+
+  /// @brief Interpolate values at the array of x.
+  void interpolate(Array1DView<const T> x, Array1DView<T> y) const noexcept {
+    assert(x.size() == y.size());
+    Range1D range{0, x.size()};
+    for_each(
+        Backend{}, range, MISO_LAMBDA(int i) {
+          y[i] = interpolate_uniform_table(table_.data(), x0_, dxi_, x[i],
+                                           table_.size());
+        });
+  }
+};
+
+// /// @brief 2D table data structure.
+// template <class T> struct Table2D {};
+
+// /// @brief Interpolator for 2D (x, y) table in the uniform grid.
+// /// @details The table is assumed to be sorted in ascending order of x and y.
+// /// The table is assumed to be uniformly spaced, i.e., x[i] = x0 + i * dx, y[j] = y0 + j * dy.
+// template <class T> class UniformTableInterpolator2D {};
+
+}  // namespace miso

--- a/miso/include/miso/table_interpolator.hpp
+++ b/miso/include/miso/table_interpolator.hpp
@@ -1,61 +1,166 @@
 #pragma once
 #include "array1d.hpp"
+#include "array2d.hpp"
+#include "array3d.hpp"
 #include "execution.hpp"
 #include "utility.hpp"
 
 namespace miso {
 
-// Interpolate a value at x.
+// Interpolate a value at x for 1D table.
 template <class T>
-__device__ __host__ T interpolate_uniform_table(const T *table, T x0, T dxi, T x,
-                                                int n) noexcept {
+__device__ __host__ T interpolate_uniform_table1d(const T *table, T x_min,
+                                                  T dx_inv, T x, int n) noexcept {
   assert(n > 1);
-  T idx = (x - x0) * dxi;
-  idx = util::clamp<T>(idx, T(0), static_cast<T>(n - 1));
-  int i = util::clamp<int>(static_cast<int>(idx), 0, n - 2);
-  T t = idx - static_cast<T>(i);
+  T fi = (x - x_min) * dx_inv;
+  fi = util::clamp<T>(fi, T(0), T(n - 1));
+  int i = util::clamp<int>(static_cast<int>(fi), 0, n - 2);
+  T t = fi - T(i);
   return (T(1) - t) * table[i] + t * table[i + 1];
 }
 
 /// @brief Interpolator for 1D (x) table in the uniform grid.
-/// @details The table is assumed to be sorted in ascending order of x.
-/// The table is assumed to be uniformly spaced, i.e., x[i] = x0 + i * dx.
+/// @details The table is assumed to be uniformly spaced, i.e., x[i] = x_min + i * dx.
 /// Value is linearly interpolated between the two nearest table entries.
 /// If x is out of the table range, the nearest table value is returned.
 template <class T, class Backend> class UniformTableInterpolator1D {
   Array1DView<T> table_;
-  T x0_, x1_, dx_, dxi_;
+  T x_min_, x_max_, dx_, dxi_;
 
 public:
   /// @brief Construct the interpolator from the table and grid parameters.
-  UniformTableInterpolator1D(const Array1DView<T> &table, T x0, T x1)
-      : table_(table), x0_(x0), x1_(x1),
-        dx_((x1 - x0) / static_cast<T>(table.size() - 1)),
-        dxi_(static_cast<T>(table.size() - 1) / (x1 - x0)) {}
-
-  /// @brief Interpolate values at the array of x.
-  T interpolate(T x) const noexcept {
-    return interpolate_uniform_table(table_.data(), x0_, dxi_, x, table_.size());
+  UniformTableInterpolator1D(const Array1DView<T> &table, T x_min, T x_max)
+      : table_(table), x_min_(x_min), x_max_(x_max),
+        dx_((x_max - x_min) / static_cast<T>(table.size() - 1)),
+        dxi_(T(1) / dx_) {
+    assert(table.size() > 1);
+    assert(x_max > x_min);
   }
 
-  /// @brief Interpolate values at the array of x.
+  /// @brief Interpolate values at x.
+  T interpolate(T x) const noexcept {
+    return interpolate_uniform_table1d(table_.data(), x_min_, dxi_, x,
+                                       table_.size());
+  }
+
+  /// @brief Interpolate values at the 1D array of x.
   void interpolate(Array1DView<const T> x, Array1DView<T> y) const noexcept {
     assert(x.size() == y.size());
     Range1D range{0, x.size()};
     for_each(
         Backend{}, range, MISO_LAMBDA(int i) {
-          y[i] = interpolate_uniform_table(table_.data(), x0_, dxi_, x[i],
-                                           table_.size());
+          y[i] = interpolate_uniform_table1d(table_.data(), x_min_, dxi_, x[i],
+                                             table_.size());
+        });
+  }
+
+  /// @brief Interpolate values at the 3D array of x.
+  void interpolate(Array3DView<const T> x, Array3DView<T> y) const noexcept {
+    assert(x.extent(0) == y.extent(0));
+    assert(x.extent(1) == y.extent(1));
+    assert(x.extent(2) == y.extent(2));
+    Range1D range{0, x.size()};
+    for_each(
+        Backend{}, range, MISO_LAMBDA(int i) {
+          y[i] = interpolate_uniform_table1d(table_.data(), x_min_, dxi_, x[i],
+                                             table_.size());
         });
   }
 };
 
-// /// @brief 2D table data structure.
-// template <class T> struct Table2D {};
+// Interpolate a value at (x0, x1) for 2D table.
+// Layout (C row-major; last index contiguous):
+//   table[i0 * n1 + i1] corresponds to a[i0][i1]
+template <class T>
+__device__ __host__ T interpolate_uniform_table2d(const T *table, T x0_min,
+                                                  T dx0_inv, T x1_min, T dx1_inv,
+                                                  T x0, T x1, int n0,
+                                                  int n1) noexcept {
+  assert(n0 > 1 && n1 > 1);
+  T fi = (x0 - x0_min) * dx0_inv;
+  fi = util::clamp<T>(fi, T(0), T(n0 - 1));
+  int i = util::clamp<int>(static_cast<int>(fi), 0, n0 - 2);
+  T t = fi - T(i);
+  T ti = T(1) - t;
 
-// /// @brief Interpolator for 2D (x, y) table in the uniform grid.
-// /// @details The table is assumed to be sorted in ascending order of x and y.
-// /// The table is assumed to be uniformly spaced, i.e., x[i] = x0 + i * dx, y[j] = y0 + j * dy.
-// template <class T> class UniformTableInterpolator2D {};
+  T fj = (x1 - x1_min) * dx1_inv;
+  fj = util::clamp<T>(fj, T(0), T(n1 - 1));
+  int j = util::clamp<int>(static_cast<int>(fj), 0, n1 - 2);
+  T u = fj - T(j);
+  T ui = T(1) - u;
+
+  int ij00 = i * n1 + j;
+  int ij01 = ij00 + 1;
+  int ij10 = ij00 + n1;
+  int ij11 = ij10 + 1;
+  return ti * ui * table[ij00] + ti * u * table[ij01] + t * ui * table[ij10] +
+         t * u * table[ij11];
+}
+
+/// @brief Interpolator for 2D (x0, x1) table in the uniform grid.
+/// @details The table is assumed to be uniformly spaced,
+/// i.e., x0[i] = x0_min + i * dx0, x1[j] = x1_min + j * dx1.
+/// Value is linearly interpolated between the two nearest table entries.
+/// If (x0, x1) is out of the table range, the nearest table value is returned.
+template <class T, class Backend> class UniformTableInterpolator2D {
+  Array2DView<T> table_;
+  T x0_min_, x0_max_, dx0_, dxi0_;
+  T x1_min_, x1_max_, dx1_, dxi1_;
+
+public:
+  /// @brief Construct the interpolator from the table and grid parameters.
+  UniformTableInterpolator2D(const Array2DView<T> &table, T x0_min, T x0_max,
+                             T x1_min, T x1_max)
+      : table_(table), x0_min_(x0_min), x0_max_(x0_max), x1_min_(x1_min),
+        x1_max_(x1_max),
+        dx0_((x0_max - x0_min) / static_cast<T>(table.extent(0) - 1)),
+        dxi0_(T(1) / dx0_),
+        dx1_((x1_max - x1_min) / static_cast<T>(table.extent(1) - 1)),
+        dxi1_(T(1) / dx1_) {
+    assert(table.extent(0) > 1);
+    assert(table.extent(1) > 1);
+    assert(x0_max > x0_min);
+    assert(x1_max > x1_min);
+  }
+
+  /// @brief Interpolate values at (x0, x1).
+  T interpolate(T x0, T x1) const noexcept {
+    return interpolate_uniform_table2d(table_.data(), x0_min_, dxi0_, x1_min_,
+                                       dxi1_, x0, x1, table_.extent(0),
+                                       table_.extent(1));
+  }
+
+  /// @brief Interpolate values at the 1D arrays of (x0, x1).
+  void interpolate(Array1DView<const T> x0, Array1DView<const T> x1,
+                   Array1DView<T> y) const noexcept {
+    assert(x0.size() == x1.size());
+    assert(x0.size() == y.size());
+    Range1D range{0, x0.size()};
+    for_each(
+        Backend{}, range, MISO_LAMBDA(int i) {
+          y[i] = interpolate_uniform_table2d(table_.data(), x0_min_, dxi0_,
+                                             x1_min_, dxi1_, x0[i], x1[i],
+                                             table_.extent(0), table_.extent(1));
+        });
+  }
+
+  /// @brief Interpolate values at the 3D array of (x0, x1).
+  void interpolate(Array3DView<const T> x0, Array3DView<const T> x1,
+                   Array3DView<T> y) const noexcept {
+    assert(x0.extent(0) == x1.extent(0));
+    assert(x0.extent(1) == x1.extent(1));
+    assert(x0.extent(2) == x1.extent(2));
+    assert(x0.extent(0) == y.extent(0));
+    assert(x0.extent(1) == y.extent(1));
+    assert(x0.extent(2) == y.extent(2));
+    Range1D range{0, x0.size()};
+    for_each(
+        Backend{}, range, MISO_LAMBDA(int i) {
+          y[i] = interpolate_uniform_table2d(table_.data(), x0_min_, dxi0_,
+                                             x1_min_, dxi1_, x0[i], x1[i],
+                                             table_.extent(0), table_.extent(1));
+        });
+  }
+};
 
 }  // namespace miso

--- a/miso/include/miso/table_interpolator.hpp
+++ b/miso/include/miso/table_interpolator.hpp
@@ -38,7 +38,7 @@ public:
   }
 
   /// @brief Interpolate values at x.
-  T interpolate(T x) const noexcept {
+  T operator()(T x) const noexcept {
     return interpolate_uniform_table1d(table_.data(), x_min_, dxi_, x,
                                        table_.size());
   }
@@ -124,7 +124,7 @@ public:
   }
 
   /// @brief Interpolate values at (x0, x1).
-  T interpolate(T x0, T x1) const noexcept {
+  T operator()(T x0, T x1) const noexcept {
     return interpolate_uniform_table2d(table_.data(), x0_min_, dxi0_, x1_min_,
                                        dxi1_, x0, x1, table_.extent(0),
                                        table_.extent(1));

--- a/miso/include/miso/utility.hpp
+++ b/miso/include/miso/utility.hpp
@@ -65,6 +65,15 @@ inline std::string zfill(int num, int width) {
   return oss.str();
 }
 
+/// @brief Clamp an integer value between lower and upper bounds.
+/// @param v value to be clamped
+/// @param lo lower bound (inclusive)
+/// @param hi upper bound (inclusive)
+/// @return clamped value (max(lo, min(v, hi)))
+template <class T> __host__ __device__ inline T clamp(T v, T lo, T hi) noexcept {
+  return v < lo ? lo : (v > hi ? hi : v);
+}
+
 /// @brief Calculate the square of a value
 /// @tparam T type of the value
 /// @param x target value

--- a/miso/include/miso/utility.hpp
+++ b/miso/include/miso/utility.hpp
@@ -65,7 +65,7 @@ inline std::string zfill(int num, int width) {
   return oss.str();
 }
 
-/// @brief Clamp an integer value between lower and upper bounds.
+/// @brief Clamp a value between lower and upper bounds.
 /// @param v value to be clamped
 /// @param lo lower bound (inclusive)
 /// @param hi upper bound (inclusive)

--- a/miso/tests/serial/test_array2d.cpp
+++ b/miso/tests/serial/test_array2d.cpp
@@ -1,0 +1,23 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+#include <miso/array2d.hpp>
+
+using namespace miso;
+
+TEST_CASE("Test Array2D CPU" * doctest::test_suite("array2d")) {
+  Array2D<int, backend::Host> arr(3, 4);
+
+  // Check dimensions
+  REQUIRE(arr.extent(0) == 3);
+  REQUIRE(arr.extent(1) == 4);
+  REQUIRE(arr.shape() == std::array<int, 2>{3, 4});
+  REQUIRE(arr.size() == 3 * 4);
+
+  // Check access
+  auto view = arr.view();
+  view(1, 2) = 42;
+  REQUIRE(arr(1, 2) == 42);
+  REQUIRE(&view(1, 2) == &arr(1, 2));
+  REQUIRE(view(1, 2) == arr[(1 * 4 + 2)]);
+}

--- a/miso/tests/serial/test_array2d.cu
+++ b/miso/tests/serial/test_array2d.cu
@@ -1,0 +1,41 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <cassert>
+#include <doctest/doctest.h>
+
+#include <miso/array2d.hpp>
+
+using namespace miso;
+
+__host__ __device__ inline double ref_value(int i, int j) {
+  return static_cast<double>(i * 10 + j);
+}
+
+__global__ void test_array2d_kernel(Array2DView<double> arr) {
+  int i = blockIdx.x * blockDim.x + threadIdx.x;
+  int j = blockIdx.y * blockDim.y + threadIdx.y;
+  if (i < arr.extent(0) && j < arr.extent(1)) {
+    arr(i, j) = ref_value(i, j);
+  }
+}
+
+TEST_CASE("Test Array2D GPU" * doctest::test_suite("array2d")) {
+  Array2D<double, backend::Host> arr(3, 4);
+  Array2D<double, backend::CUDA> arr_d(3, 4);
+
+  const auto [nx0, nx1] = arr.shape();
+  for (int i = 0; i < nx0; ++i) {
+    for (int j = 0; j < nx1; ++j) {
+      arr(i, j) = ref_value(i, j);
+    }
+  }
+
+  arr_d.copy_from(arr);
+  test_array2d_kernel<<<dim3(1, 1, 1), dim3(3, 4, 1)>>>(arr_d.view());
+
+  arr.copy_from(arr_d);
+  for (int i = 0; i < nx0; ++i) {
+    for (int j = 0; j < nx1; ++j) {
+      REQUIRE(std::abs(arr(i, j) - ref_value(i, j)) < 1e-9);
+    }
+  }
+}

--- a/miso/tests/serial/test_table_interpolator.cpp
+++ b/miso/tests/serial/test_table_interpolator.cpp
@@ -1,0 +1,61 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+#include <miso/table_interpolator.hpp>
+
+using namespace miso;
+
+TEST_CASE("Test Table Interpolator in CUDA backend" *
+          doctest::test_suite("table_interpolator")) {
+  // Table data and interpolator
+  constexpr int Nt = 5;
+  constexpr float x0 = 0.f;
+  constexpr float x1 = static_cast<float>(Nt - 1);
+  Array1D<float, backend::Host> table_h(Nt);
+  for (int i = 0; i < Nt; ++i) {
+    table_h[i] = static_cast<float>(i * i);
+  }
+  UniformTableInterpolator1D<float, backend::Host> interpolator(table_h.view(),
+                                                                x0, x1);
+
+  // Check the interpolator at the table points.
+  {
+    constexpr int Nx = Nt;
+    Array1D<float, backend::Host> out_h(Nx);
+    Array1D<float, backend::Host> in_h(Nx);
+    for (int i = 0; i < Nx; ++i) {
+      in_h[i] = static_cast<float>(i);
+    }
+    interpolator.interpolate(in_h.const_view(), out_h.view());
+    for (int i = 0; i < Nx; ++i) {
+      REQUIRE(std::abs(out_h[i] - table_h[i]) < 1e-5f);
+    }
+  }
+
+  // Check the interpolator between the table points.
+  {
+    constexpr int Nx = Nt - 1;
+    Array1D<float, backend::Host> out_h(Nx);
+    Array1D<float, backend::Host> in_h(Nx);
+    for (int i = 0; i < Nx; ++i) {
+      in_h[i] = static_cast<float>(i) + 0.5f;
+    }
+    interpolator.interpolate(in_h.const_view(), out_h.view());
+    for (int i = 0; i < Nx; ++i) {
+      REQUIRE(std::abs(out_h[i] - 0.5f * (table_h[i] + table_h[i + 1])) < 1e-5f);
+    }
+  }
+
+  // Check the interpolator outside the table range.
+  {
+    constexpr int Nx = 2;
+    Array1D<float, backend::Host> out_h(Nx);
+    Array1D<float, backend::Host> in_h(Nx);
+    in_h[0] = x0 - 0.5f;
+    in_h[1] = x1 + 0.5f;
+    interpolator.interpolate(in_h.const_view(), out_h.view());
+    std::printf("out_h[0] = %f, out_h[1] = %f\n", out_h[0], out_h[1]);
+    REQUIRE(std::abs(out_h[0] - table_h[0]) < 1e-5f);
+    REQUIRE(std::abs(out_h[1] - table_h[Nt - 1]) < 1e-5f);
+  }
+}

--- a/miso/tests/serial/test_table_interpolator.cpp
+++ b/miso/tests/serial/test_table_interpolator.cpp
@@ -5,18 +5,18 @@
 
 using namespace miso;
 
-TEST_CASE("Test Table Interpolator in CUDA backend" *
+TEST_CASE("Test Table Interpolator in Host backend" *
           doctest::test_suite("table_interpolator")) {
   // Table data and interpolator
   constexpr int Nt = 5;
-  constexpr float x0 = 0.f;
-  constexpr float x1 = static_cast<float>(Nt - 1);
+  constexpr float x_min = 0.f;
+  constexpr float x_max = static_cast<float>(Nt - 1);
   Array1D<float, backend::Host> table_h(Nt);
   for (int i = 0; i < Nt; ++i) {
     table_h[i] = static_cast<float>(i * i);
   }
   UniformTableInterpolator1D<float, backend::Host> interpolator(table_h.view(),
-                                                                x0, x1);
+                                                                x_min, x_max);
 
   // Check the interpolator at the table points.
   {
@@ -51,10 +51,97 @@ TEST_CASE("Test Table Interpolator in CUDA backend" *
     constexpr int Nx = 2;
     Array1D<float, backend::Host> out_h(Nx);
     Array1D<float, backend::Host> in_h(Nx);
-    in_h[0] = x0 - 0.5f;
-    in_h[1] = x1 + 0.5f;
+    in_h[0] = x_min - 0.5f;
+    in_h[1] = x_max + 0.5f;
     interpolator.interpolate(in_h.const_view(), out_h.view());
     REQUIRE(std::abs(out_h[0] - table_h[0]) < 1e-5f);
     REQUIRE(std::abs(out_h[1] - table_h[Nt - 1]) < 1e-5f);
+  }
+}
+
+TEST_CASE("Test UniformTableInterpolator2D in Host backend" *
+          doctest::test_suite("table_interpolator")) {
+  // Table data and interpolator
+  constexpr int Nt0 = 2;
+  constexpr int Nt1 = 3;
+  constexpr float x0_min = 0.f;
+  constexpr float x0_max = static_cast<float>(Nt0 - 1);
+  constexpr float x1_min = 0.f;
+  constexpr float x1_max = static_cast<float>(Nt1 - 1);
+  Array2D<float, backend::Host> table_h(Nt0, Nt1);
+  for (int i = 0; i < Nt0; ++i) {
+    for (int j = 0; j < Nt1; ++j) {
+      table_h(i, j) = static_cast<float>(i * j);
+    }
+  }
+  UniformTableInterpolator2D<float, backend::Host> interpolator(
+      table_h.view(), x0_min, x0_max, x1_min, x1_max);
+
+  // Check the interpolator at the table points.
+  {
+    constexpr int Nx0 = Nt0;
+    constexpr int Nx1 = Nt1;
+    Array3D<float, backend::Host> out_h(Nx0, Nx1, 1);
+    Array3D<float, backend::Host> in0_h(Nx0, Nx1, 1);
+    Array3D<float, backend::Host> in1_h(Nx0, Nx1, 1);
+    for (int i = 0; i < Nx0; ++i) {
+      for (int j = 0; j < Nx1; ++j) {
+        in0_h(i, j, 0) = static_cast<float>(i);
+        in1_h(i, j, 0) = static_cast<float>(j);
+      }
+    }
+    interpolator.interpolate(in0_h.const_view(), in1_h.const_view(),
+                             out_h.view());
+    for (int i = 0; i < Nx0 * Nx1; ++i) {
+      REQUIRE(std::abs(out_h[i] - table_h[i]) < 1e-5f);
+    }
+  }
+
+  // Check the interpolator between the table points.
+  {
+    constexpr int Nx0 = Nt0 - 1;
+    constexpr int Nx1 = Nt1 - 1;
+    Array3D<float, backend::Host> out_h(Nx0, Nx1, 1);
+    Array3D<float, backend::Host> in0_h(Nx0, Nx1, 1);
+    Array3D<float, backend::Host> in1_h(Nx0, Nx1, 1);
+    for (int i = 0; i < Nx0; ++i) {
+      for (int j = 0; j < Nx1; ++j) {
+        in0_h(i, j, 0) = static_cast<float>(i) + 0.5f;
+        in1_h(i, j, 0) = static_cast<float>(j) + 0.5f;
+      }
+    }
+    interpolator.interpolate(in0_h.const_view(), in1_h.const_view(),
+                             out_h.view());
+    for (int i = 0; i < Nx0; ++i) {
+      for (int j = 0; j < Nx1; ++j) {
+        const float expected =
+            0.25f * (table_h(i, j) + table_h(i + 1, j) + table_h(i, j + 1) +
+                     table_h(i + 1, j + 1));
+        REQUIRE(std::abs(out_h(i, j, 0) - expected) < 1e-5f);
+      }
+    }
+  }
+
+  // Check the interpolator outside the table range.
+  {
+    constexpr int Nx0 = 2;
+    constexpr int Nx1 = 2;
+    Array3D<float, backend::Host> out_h(Nx0, Nx1, 1);
+    Array3D<float, backend::Host> in0_h(Nx0, Nx1, 1);
+    Array3D<float, backend::Host> in1_h(Nx0, Nx1, 1);
+    in0_h(0, 0, 0) = x0_min - 0.5f;
+    in0_h(0, 1, 0) = x0_min - 0.5f;
+    in0_h(1, 0, 0) = x0_max + 0.5f;
+    in0_h(1, 1, 0) = x0_max + 0.5f;
+    in1_h(0, 0, 0) = x1_min - 0.5f;
+    in1_h(0, 1, 0) = x1_max + 0.5f;
+    in1_h(1, 0, 0) = x1_min - 0.5f;
+    in1_h(1, 1, 0) = x1_max + 0.5f;
+    interpolator.interpolate(in0_h.const_view(), in1_h.const_view(),
+                             out_h.view());
+    REQUIRE(std::abs(out_h(0, 0, 0) - table_h(0, 0)) < 1e-5f);
+    REQUIRE(std::abs(out_h(0, 1, 0) - table_h(0, Nt1 - 1)) < 1e-5f);
+    REQUIRE(std::abs(out_h(1, 0, 0) - table_h(Nt0 - 1, 0)) < 1e-5f);
+    REQUIRE(std::abs(out_h(1, 1, 0) - table_h(Nt0 - 1, Nt1 - 1)) < 1e-5f);
   }
 }

--- a/miso/tests/serial/test_table_interpolator.cpp
+++ b/miso/tests/serial/test_table_interpolator.cpp
@@ -54,7 +54,6 @@ TEST_CASE("Test Table Interpolator in CUDA backend" *
     in_h[0] = x0 - 0.5f;
     in_h[1] = x1 + 0.5f;
     interpolator.interpolate(in_h.const_view(), out_h.view());
-    std::printf("out_h[0] = %f, out_h[1] = %f\n", out_h[0], out_h[1]);
     REQUIRE(std::abs(out_h[0] - table_h[0]) < 1e-5f);
     REQUIRE(std::abs(out_h[1] - table_h[Nt - 1]) < 1e-5f);
   }

--- a/miso/tests/serial/test_table_interpolator.cpp
+++ b/miso/tests/serial/test_table_interpolator.cpp
@@ -71,7 +71,7 @@ TEST_CASE("Test UniformTableInterpolator2D in Host backend" *
   Array2D<float, backend::Host> table_h(Nt0, Nt1);
   for (int i = 0; i < Nt0; ++i) {
     for (int j = 0; j < Nt1; ++j) {
-      table_h(i, j) = static_cast<float>(i * j);
+      table_h(i, j) = static_cast<float>(100 * i * i + j * j);
     }
   }
   UniformTableInterpolator2D<float, backend::Host> interpolator(

--- a/miso/tests/serial/test_table_interpolator.cpp
+++ b/miso/tests/serial/test_table_interpolator.cpp
@@ -5,7 +5,7 @@
 
 using namespace miso;
 
-TEST_CASE("Test Table Interpolator in Host backend" *
+TEST_CASE("Test UniformTableInterpolator1D in Host backend" *
           doctest::test_suite("table_interpolator")) {
   // Table data and interpolator
   constexpr int Nt = 5;

--- a/miso/tests/serial/test_table_interpolator.cu
+++ b/miso/tests/serial/test_table_interpolator.cu
@@ -1,0 +1,75 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+#include <miso/table_interpolator.hpp>
+
+using namespace miso;
+
+TEST_CASE("Test Table Interpolator in CUDA backend" *
+          doctest::test_suite("table_interpolator")) {
+  // Table data and interpolator
+  constexpr int Nt = 5;
+  constexpr float x0 = 0.f;
+  constexpr float x1 = static_cast<float>(Nt - 1);
+  Array1D<float, backend::Host> table_h(Nt);
+  for (int i = 0; i < Nt; ++i) {
+    table_h[i] = static_cast<float>(i * i);
+  }
+  Array1D<float, backend::CUDA> table_d(Nt);
+  table_d.copy_from(table_h);
+  UniformTableInterpolator1D<float, backend::CUDA> interpolator(table_d.view(),
+                                                                x0, x1);
+
+  // Check the interpolator at the table points.
+  {
+    constexpr int Nx = Nt;
+    Array1D<float, backend::Host> out_h(Nx);
+    Array1D<float, backend::CUDA> out_d(Nx);
+    Array1D<float, backend::Host> in_h(Nx);
+    Array1D<float, backend::CUDA> in_d(Nx);
+    for (int i = 0; i < Nx; ++i) {
+      in_h[i] = static_cast<float>(i);
+    }
+    in_d.copy_from(in_h);
+    interpolator.interpolate(in_d.const_view(), out_d.view());
+    out_h.copy_from(out_d);
+    for (int i = 0; i < Nx; ++i) {
+      REQUIRE(std::abs(out_h[i] - table_h[i]) < 1e-5f);
+    }
+  }
+
+  // Check the interpolator between the table points.
+  {
+    constexpr int Nx = Nt - 1;
+    Array1D<float, backend::Host> out_h(Nx);
+    Array1D<float, backend::CUDA> out_d(Nx);
+    Array1D<float, backend::Host> in_h(Nx);
+    Array1D<float, backend::CUDA> in_d(Nx);
+    for (int i = 0; i < Nx; ++i) {
+      in_h[i] = static_cast<float>(i) + 0.5f;
+    }
+    in_d.copy_from(in_h);
+    interpolator.interpolate(in_d.const_view(), out_d.view());
+    out_h.copy_from(out_d);
+    for (int i = 0; i < Nx; ++i) {
+      REQUIRE(std::abs(out_h[i] - 0.5f * (table_h[i] + table_h[i + 1])) < 1e-5f);
+    }
+  }
+
+  // Check the interpolator outside the table range.
+  {
+    constexpr int Nx = 2;
+    Array1D<float, backend::Host> out_h(Nx);
+    Array1D<float, backend::CUDA> out_d(Nx);
+    Array1D<float, backend::Host> in_h(Nx);
+    Array1D<float, backend::CUDA> in_d(Nx);
+    in_h[0] = x0 - 0.5f;
+    in_h[1] = x1 + 0.5f;
+    in_d.copy_from(in_h);
+    interpolator.interpolate(in_d.const_view(), out_d.view());
+    out_h.copy_from(out_d);
+    std::printf("out_h[0] = %f, out_h[1] = %f\n", out_h[0], out_h[1]);
+    REQUIRE(std::abs(out_h[0] - table_h[0]) < 1e-5f);
+    REQUIRE(std::abs(out_h[1] - table_h[Nt - 1]) < 1e-5f);
+  }
+}

--- a/miso/tests/serial/test_table_interpolator.cu
+++ b/miso/tests/serial/test_table_interpolator.cu
@@ -85,7 +85,7 @@ TEST_CASE("Test UniformTableInterpolator2D in CUDA backend" *
   Array2D<float, backend::Host> table_h(Nt0, Nt1);
   for (int i = 0; i < Nt0; ++i) {
     for (int j = 0; j < Nt1; ++j) {
-      table_h(i, j) = static_cast<float>(i * j);
+      table_h(i, j) = static_cast<float>(100 * i * i + j * j);
     }
   }
   Array2D<float, backend::CUDA> table_d(Nt0, Nt1);

--- a/miso/tests/serial/test_table_interpolator.cu
+++ b/miso/tests/serial/test_table_interpolator.cu
@@ -5,12 +5,12 @@
 
 using namespace miso;
 
-TEST_CASE("Test Table Interpolator in CUDA backend" *
+TEST_CASE("Test UniformTableInterpolator1D in CUDA backend" *
           doctest::test_suite("table_interpolator")) {
   // Table data and interpolator
   constexpr int Nt = 5;
-  constexpr float x0 = 0.f;
-  constexpr float x1 = static_cast<float>(Nt - 1);
+  constexpr float x_min = 0.f;
+  constexpr float x_max = static_cast<float>(Nt - 1);
   Array1D<float, backend::Host> table_h(Nt);
   for (int i = 0; i < Nt; ++i) {
     table_h[i] = static_cast<float>(i * i);
@@ -18,7 +18,7 @@ TEST_CASE("Test Table Interpolator in CUDA backend" *
   Array1D<float, backend::CUDA> table_d(Nt);
   table_d.copy_from(table_h);
   UniformTableInterpolator1D<float, backend::CUDA> interpolator(table_d.view(),
-                                                                x0, x1);
+                                                                x_min, x_max);
 
   // Check the interpolator at the table points.
   {
@@ -63,12 +63,119 @@ TEST_CASE("Test Table Interpolator in CUDA backend" *
     Array1D<float, backend::CUDA> out_d(Nx);
     Array1D<float, backend::Host> in_h(Nx);
     Array1D<float, backend::CUDA> in_d(Nx);
-    in_h[0] = x0 - 0.5f;
-    in_h[1] = x1 + 0.5f;
+    in_h[0] = x_min - 0.5f;
+    in_h[1] = x_max + 0.5f;
     in_d.copy_from(in_h);
     interpolator.interpolate(in_d.const_view(), out_d.view());
     out_h.copy_from(out_d);
     REQUIRE(std::abs(out_h[0] - table_h[0]) < 1e-5f);
     REQUIRE(std::abs(out_h[1] - table_h[Nt - 1]) < 1e-5f);
+  }
+}
+
+TEST_CASE("Test UniformTableInterpolator2D in CUDA backend" *
+          doctest::test_suite("table_interpolator")) {
+  // Table data and interpolator
+  constexpr int Nt0 = 2;
+  constexpr int Nt1 = 3;
+  constexpr float x0_min = 0.f;
+  constexpr float x0_max = static_cast<float>(Nt0 - 1);
+  constexpr float x1_min = 0.f;
+  constexpr float x1_max = static_cast<float>(Nt1 - 1);
+  Array2D<float, backend::Host> table_h(Nt0, Nt1);
+  for (int i = 0; i < Nt0; ++i) {
+    for (int j = 0; j < Nt1; ++j) {
+      table_h(i, j) = static_cast<float>(i * j);
+    }
+  }
+  Array2D<float, backend::CUDA> table_d(Nt0, Nt1);
+  table_d.copy_from(table_h);
+  UniformTableInterpolator2D<float, backend::CUDA> interpolator(
+      table_d.view(), x0_min, x0_max, x1_min, x1_max);
+
+  // Check the interpolator at the table points.
+  {
+    constexpr int Nx0 = Nt0;
+    constexpr int Nx1 = Nt1;
+    Array3D<float, backend::Host> out_h(Nx0, Nx1, 1);
+    Array3D<float, backend::CUDA> out_d(Nx0, Nx1, 1);
+    Array3D<float, backend::Host> in0_h(Nx0, Nx1, 1);
+    Array3D<float, backend::CUDA> in0_d(Nx0, Nx1, 1);
+    Array3D<float, backend::Host> in1_h(Nx0, Nx1, 1);
+    Array3D<float, backend::CUDA> in1_d(Nx0, Nx1, 1);
+    for (int i = 0; i < Nx0; ++i) {
+      for (int j = 0; j < Nx1; ++j) {
+        in0_h(i, j, 0) = static_cast<float>(i);
+        in1_h(i, j, 0) = static_cast<float>(j);
+      }
+    }
+    in0_d.copy_from(in0_h);
+    in1_d.copy_from(in1_h);
+    interpolator.interpolate(in0_d.const_view(), in1_d.const_view(),
+                             out_d.view());
+    out_h.copy_from(out_d);
+    for (int i = 0; i < Nx0 * Nx1; ++i) {
+      REQUIRE(std::abs(out_h[i] - table_h[i]) < 1e-5f);
+    }
+  }
+
+  // Check the interpolator between the table points.
+  {
+    constexpr int Nx0 = Nt0 - 1;
+    constexpr int Nx1 = Nt1 - 1;
+    Array3D<float, backend::Host> out_h(Nx0, Nx1, 1);
+    Array3D<float, backend::CUDA> out_d(Nx0, Nx1, 1);
+    Array3D<float, backend::Host> in0_h(Nx0, Nx1, 1);
+    Array3D<float, backend::CUDA> in0_d(Nx0, Nx1, 1);
+    Array3D<float, backend::Host> in1_h(Nx0, Nx1, 1);
+    Array3D<float, backend::CUDA> in1_d(Nx0, Nx1, 1);
+    for (int i = 0; i < Nx0; ++i) {
+      for (int j = 0; j < Nx1; ++j) {
+        in0_h(i, j, 0) = static_cast<float>(i) + 0.5f;
+        in1_h(i, j, 0) = static_cast<float>(j) + 0.5f;
+      }
+    }
+    in0_d.copy_from(in0_h);
+    in1_d.copy_from(in1_h);
+    interpolator.interpolate(in0_d.const_view(), in1_d.const_view(),
+                             out_d.view());
+    out_h.copy_from(out_d);
+    for (int i = 0; i < Nx0; ++i) {
+      for (int j = 0; j < Nx1; ++j) {
+        const float expected =
+            0.25f * (table_h(i, j) + table_h(i + 1, j) + table_h(i, j + 1) +
+                     table_h(i + 1, j + 1));
+        REQUIRE(std::abs(out_h(i, j, 0) - expected) < 1e-5f);
+      }
+    }
+  }
+
+  // Check the interpolator outside the table range.
+  {
+    constexpr int Nx0 = 2;
+    constexpr int Nx1 = 2;
+    Array3D<float, backend::Host> out_h(Nx0, Nx1, 1);
+    Array3D<float, backend::CUDA> out_d(Nx0, Nx1, 1);
+    Array3D<float, backend::Host> in0_h(Nx0, Nx1, 1);
+    Array3D<float, backend::CUDA> in0_d(Nx0, Nx1, 1);
+    Array3D<float, backend::Host> in1_h(Nx0, Nx1, 1);
+    Array3D<float, backend::CUDA> in1_d(Nx0, Nx1, 1);
+    in0_h(0, 0, 0) = x0_min - 0.5f;
+    in0_h(0, 1, 0) = x0_min - 0.5f;
+    in0_h(1, 0, 0) = x0_max + 0.5f;
+    in0_h(1, 1, 0) = x0_max + 0.5f;
+    in1_h(0, 0, 0) = x1_min - 0.5f;
+    in1_h(0, 1, 0) = x1_max + 0.5f;
+    in1_h(1, 0, 0) = x1_min - 0.5f;
+    in1_h(1, 1, 0) = x1_max + 0.5f;
+    in0_d.copy_from(in0_h);
+    in1_d.copy_from(in1_h);
+    interpolator.interpolate(in0_d.const_view(), in1_d.const_view(),
+                             out_d.view());
+    out_h.copy_from(out_d);
+    REQUIRE(std::abs(out_h(0, 0, 0) - table_h(0, 0)) < 1e-5f);
+    REQUIRE(std::abs(out_h(0, 1, 0) - table_h(0, Nt1 - 1)) < 1e-5f);
+    REQUIRE(std::abs(out_h(1, 0, 0) - table_h(Nt0 - 1, 0)) < 1e-5f);
+    REQUIRE(std::abs(out_h(1, 1, 0) - table_h(Nt0 - 1, Nt1 - 1)) < 1e-5f);
   }
 }

--- a/miso/tests/serial/test_table_interpolator.cu
+++ b/miso/tests/serial/test_table_interpolator.cu
@@ -68,7 +68,6 @@ TEST_CASE("Test Table Interpolator in CUDA backend" *
     in_d.copy_from(in_h);
     interpolator.interpolate(in_d.const_view(), out_d.view());
     out_h.copy_from(out_d);
-    std::printf("out_h[0] = %f, out_h[1] = %f\n", out_h[0], out_h[1]);
     REQUIRE(std::abs(out_h[0] - table_h[0]) < 1e-5f);
     REQUIRE(std::abs(out_h[1] - table_h[Nt - 1]) < 1e-5f);
   }


### PR DESCRIPTION
1D/2Dテーブルからの補間機能と、MHDソルバの一般状態方程式への対応を行いました。
理想気体を仮定するデモ問題ではそのまま比熱比を使って初期条件などを決める想定です(デモもそのまま動きます)。

現実的な状態方程式を利用した面白そうなデモ問題は、少し探してみましたが見つかりませんでした。
何か良いのがあれば独立したPRで実装すると良いと思います。

---

このプルリクエストでは、ホストおよびCUDAデバイスメモリの両方に対応した新しい汎用2次元配列抽象を導入し、磁気流体力学（MHD）インテグレータおよび人工粘性コードを、より表現力が高く再利用可能な状態方程式（EOS）インターフェースを用いる形にリファクタリングしました。これらの変更により、EOS演算をカプセル化し、その場しのぎの数式記述を専用メソッドに置き換えることで、コードの可読性・柔軟性・保守性が向上しています。また、数学ユーティリティ関数の標準化も行いました。

---

### 新しい配列抽象

* `miso/include/miso/array2d.hpp` に `Array2D` および `Array2DView` クラスを追加しました。
  これにより、ホストおよびCUDAデバイスメモリの両方に対応する、柔軟・軽量・バックエンド非依存な2次元配列インターフェースを提供します。
  ムーブセマンティクスおよびメモリ空間間のコピー機能も備えています。

---

### EOSインターフェースのリファクタリング

* `IdealEOS` に圧力や音速計算のための新メソッド（`roeitopr`、`roeitocs` など）を導入しました。
* MHDインテグレータおよび人工粘性モジュール全体で、直接的な数式計算の代わりにこれらのメソッドを使用するようリファクタリングしました。
  これにより可読性が向上し、他のEOS型への拡張が容易になります。

---

### CUDAカーネルインターフェースの改善

* 人工粘性およびインテグレータモジュール内のCUDAカーネルとその起動コードを更新し、従来の生パラメータではなくEOSオブジェクトを受け取るようにしました。
  これにより、より柔軟で汎用的なEOS処理が可能になります。

---

### 数学ユーティリティの標準化

* `std::sqrt`、`std::exp`、`std::min` の直接呼び出しを、
  `util::sqrt`、`util::exp`、`util::min2`、`util::min3` に置き換えました。
  これにより一貫性とデバイス互換性を確保しています。

---

### その他の改善

* EOS計算で使用する新しいユーティリティ関数をサポートするため、`miso/include/miso/eos.hpp` に `utility.hpp` をインクルードしました。
