### PR TITLE
config.yamlの再検討

### DIFF
--- a/demo/hd1d_shock_tube/config/config_x.yaml
+++ b/demo/hd1d_shock_tube/config/config_x.yaml
@@ -1,10 +1,13 @@
-base:
-  save_dir: ../data_x/
+io:
+  enabled: true
   continue: false
+  save_dir: ../data_x/
+  time_save_dir: time/
+  mpi_save_dir: mpi/
+  mhd_save_dir: mhd/
+  n_output_digits: 8
 
 time:
-  time_save_dir: time/
-  n_output_digits: 8
   tend: 0.2
   dt_output: 0.01
 
@@ -21,7 +24,6 @@ grid:
   z_max: 1.0
 
 mpi:
-  mpi_save_dir: mpi/
   x_procs: 1
   y_procs: 1
   z_procs: 1
@@ -33,8 +35,6 @@ domain:
     z: false
 
 mhd:
-  mhd_save_dir: mhd/
-  n_output_digits: 8
   cfl_number: 0.5
   artificial_viscosity:
     ep: 1.0

--- a/demo/hd1d_shock_tube/config/config_x.yaml
+++ b/demo/hd1d_shock_tube/config/config_x.yaml
@@ -1,11 +1,6 @@
 io:
-  enabled: true
   continue: false
   save_dir: ../data_x/
-  time_save_dir: time/
-  mpi_save_dir: mpi/
-  mhd_save_dir: mhd/
-  n_output_digits: 8
 
 time:
   tend: 0.2
@@ -35,14 +30,6 @@ domain:
     z: false
 
 mhd:
-  cfl_number: 0.5
-  artificial_viscosity:
-    ep: 1.0
-    fh: 1.0
-    # for characteristic velocity
-    cs_fac: 1.0
-    ca_fac: 1.0
-    vv_fac: 1.0
 
 eos:
   gm: 1.4

--- a/demo/hd1d_shock_tube/config/config_y.yaml
+++ b/demo/hd1d_shock_tube/config/config_y.yaml
@@ -1,11 +1,6 @@
 io:
-  enabled: true
   continue: false
   save_dir: ../data_y/
-  time_save_dir: time/
-  mpi_save_dir: mpi/
-  mhd_save_dir: mhd/
-  n_output_digits: 8
 
 time:
   tend: 0.2
@@ -35,14 +30,6 @@ domain:
     z: false
 
 mhd:
-  cfl_number: 0.5
-  artificial_viscosity:
-    ep: 1.0
-    fh: 1.0
-    # for characteristic velocity
-    cs_fac: 1.0
-    ca_fac: 1.0
-    vv_fac: 1.0
 
 eos:
   gm: 1.4

--- a/demo/hd1d_shock_tube/config/config_y.yaml
+++ b/demo/hd1d_shock_tube/config/config_y.yaml
@@ -1,10 +1,13 @@
-base:
-  save_dir: ../data_y/
+io:
+  enabled: true
   continue: false
+  save_dir: ../data_y/
+  time_save_dir: time/
+  mpi_save_dir: mpi/
+  mhd_save_dir: mhd/
+  n_output_digits: 8
 
 time:
-  time_save_dir: time/
-  n_output_digits: 8
   tend: 0.2
   dt_output: 0.01
 
@@ -21,7 +24,6 @@ grid:
   z_max: 1.0
 
 mpi:
-  mpi_save_dir: mpi/
   x_procs: 1
   y_procs: 1
   z_procs: 1
@@ -33,8 +35,6 @@ domain:
     z: false
 
 mhd:
-  mhd_save_dir: mhd/
-  n_output_digits: 8
   cfl_number: 0.5
   artificial_viscosity:
     ep: 1.0

--- a/demo/hd1d_shock_tube/config/config_z.yaml
+++ b/demo/hd1d_shock_tube/config/config_z.yaml
@@ -1,11 +1,6 @@
 io:
-  enabled: true
   continue: false
   save_dir: ../data_z/
-  time_save_dir: time/
-  mpi_save_dir: mpi/
-  mhd_save_dir: mhd/
-  n_output_digits: 8
 
 time:
   tend: 0.2
@@ -35,14 +30,6 @@ domain:
     z: false
 
 mhd:
-  cfl_number: 0.5
-  artificial_viscosity:
-    ep: 1.0
-    fh: 1.0
-    # for characteristic velocity
-    cs_fac: 1.0
-    ca_fac: 1.0
-    vv_fac: 1.0
 
 eos:
   gm: 1.4

--- a/demo/hd1d_shock_tube/config/config_z.yaml
+++ b/demo/hd1d_shock_tube/config/config_z.yaml
@@ -1,10 +1,13 @@
-base:
-  save_dir: ../data_z/
+io:
+  enabled: true
   continue: false
+  save_dir: ../data_z/
+  time_save_dir: time/
+  mpi_save_dir: mpi/
+  mhd_save_dir: mhd/
+  n_output_digits: 8
 
 time:
-  time_save_dir: time/
-  n_output_digits: 8
   tend: 0.2
   dt_output: 0.01
 
@@ -21,7 +24,6 @@ grid:
   z_max: 1.0
 
 mpi:
-  mpi_save_dir: mpi/
   x_procs: 1
   y_procs: 1
   z_procs: 1
@@ -33,8 +35,6 @@ domain:
     z: false
 
 mhd:
-  mhd_save_dir: mhd/
-  n_output_digits: 8
   cfl_number: 0.5
   artificial_viscosity:
     ep: 1.0

--- a/demo/hd2d_kelvin_helmholtz/config.yaml
+++ b/demo/hd2d_kelvin_helmholtz/config.yaml
@@ -1,13 +1,7 @@
-base:
-  save_dir: data/
-  # if save_dir exiests
-  # continue: true -> continue simulation
-  # continue: false -> start from scratch
+io:
   continue: true
 
 time:
-  time_save_dir: time/
-  n_output_digits: 8
   tend: 2.0
   dt_output: 0.02
 
@@ -24,7 +18,6 @@ grid:
   z_max:  0.5
 
 mpi:
-  mpi_save_dir: mpi/
   x_procs: 2
   y_procs: 1
   z_procs: 1
@@ -36,16 +29,6 @@ domain:
     z: true
 
 mhd:
-  mhd_save_dir: mhd/
-  n_output_digits: 8
-  cfl_number: 1.0
-  artificial_viscosity:
-    ep: 1.5
-    fh: 1.5
-    # for characteristic velocity
-    cs_fac: 0.5
-    ca_fac: 1.0
-    vv_fac: 1.0
 
 eos:
   gm: 1.4

--- a/demo/hd2d_rayleigh_taylor/config.yaml
+++ b/demo/hd2d_rayleigh_taylor/config.yaml
@@ -1,13 +1,7 @@
-base:
-  save_dir: data/
-  # if save_dir exiests
-  # continue: true -> continue simulation
-  # continue: false -> start from scratch
+io:
   continue: true
 
 time:
-  time_save_dir: time/
-  n_output_digits: 8
   tend: 20.0
   dt_output: 0.2
 
@@ -24,7 +18,6 @@ grid:
   z_max:  0.25
 
 mpi:
-  mpi_save_dir: mpi/
   x_procs: 1
   y_procs: 2
   z_procs: 1
@@ -37,9 +30,6 @@ domain:
     z: true
 
 mhd:
-  mhd_save_dir: mhd/
-  n_output_digits: 8
-  cfl_number: 0.5
   artificial_viscosity:
     ep: 2.0
     fh: 2.0

--- a/demo/mhd1d_shock_tube/config/config_x.yaml
+++ b/demo/mhd1d_shock_tube/config/config_x.yaml
@@ -1,10 +1,8 @@
-base:
+io:
   save_dir: ../data_x/
   continue: false
 
 time:
-  time_save_dir: time/
-  n_output_digits: 8
   tend: 0.2
   dt_output: 0.01
 
@@ -21,7 +19,6 @@ grid:
   z_max: 1.0
 
 mpi:
-  mpi_save_dir: mpi/
   x_procs: 1
   y_procs: 1
   z_procs: 1
@@ -33,16 +30,6 @@ domain:
     z: false
 
 mhd:
-  mhd_save_dir: mhd/
-  n_output_digits: 8
-  cfl_number: 0.5
-  artificial_viscosity:
-    ep: 1.0
-    fh: 1.0
-    # for characteristic velocity
-    cs_fac: 1.0
-    ca_fac: 1.0
-    vv_fac: 1.0
 
 eos:
   gm: 2.0

--- a/demo/mhd1d_shock_tube/config/config_y.yaml
+++ b/demo/mhd1d_shock_tube/config/config_y.yaml
@@ -1,10 +1,8 @@
-base:
+io:
   save_dir: ../data_y/
   continue: false
 
 time:
-  time_save_dir: time/
-  n_output_digits: 8
   tend: 0.2
   dt_output: 0.01
 
@@ -21,7 +19,6 @@ grid:
   z_max: 1.0
 
 mpi:
-  mpi_save_dir: mpi/
   x_procs: 1
   y_procs: 1
   z_procs: 1
@@ -33,19 +30,10 @@ domain:
     z: false
 
 mhd:
-  mhd_save_dir: mhd/
-  n_output_digits: 8
-  cfl_number: 0.5
-  artificial_viscosity:
-    ep: 1.0
-    fh: 1.0
-    # for characteristic velocity
-    cs_fac: 1.0
-    ca_fac: 1.0
-    vv_fac: 1.0
 
 eos:
   gm: 2.0
+
 
 shock_tube:
   bm: 0.75

--- a/demo/mhd1d_shock_tube/config/config_z.yaml
+++ b/demo/mhd1d_shock_tube/config/config_z.yaml
@@ -1,10 +1,8 @@
-base:
+io:
   save_dir: ../data_z/
   continue: false
 
 time:
-  time_save_dir: time/
-  n_output_digits: 8
   tend: 0.2
   dt_output: 0.01
 
@@ -21,7 +19,6 @@ grid:
   z_max: 1.0
 
 mpi:
-  mpi_save_dir: mpi/
   x_procs: 1
   y_procs: 1
   z_procs: 1
@@ -33,19 +30,10 @@ domain:
     z: false
 
 mhd:
-  mhd_save_dir: mhd/
-  n_output_digits: 8
-  cfl_number: 0.5
-  artificial_viscosity:
-    ep: 1.0
-    fh: 1.0
-    # for characteristic velocity
-    cs_fac: 1.0
-    ca_fac: 1.0
-    vv_fac: 1.0
 
 eos:
   gm: 2.0
+
 
 shock_tube:
   bm: 0.75

--- a/demo/mhd2d_vortex/config.yaml
+++ b/demo/mhd2d_vortex/config.yaml
@@ -1,13 +1,7 @@
-base:
-  save_dir: data/
-  # if save_dir exists
-  # continue: true -> continue simulation
-  # continue: false -> start from scratch
+io:
   continue: true
 
 time:
-  time_save_dir: time/
-  n_output_digits: 8
   tend: 0.8
   dt_output: 0.01
 
@@ -24,7 +18,6 @@ grid:
   z_max: 1.0
 
 mpi:
-  mpi_save_dir: mpi/
   x_procs: 2
   y_procs: 1
   z_procs: 1
@@ -36,8 +29,6 @@ domain:
     z: true
 
 mhd:
-  mhd_save_dir: mhd/
-  n_output_digits: 8
   cfl_number: 1.0
   artificial_viscosity:
     ep: 1.5

--- a/demo/mhd3d_magnetosphere/config.yaml
+++ b/demo/mhd3d_magnetosphere/config.yaml
@@ -1,13 +1,7 @@
-base:
-  save_dir: data/
-  # if save_dir exists
-  # continue: true -> continue simulation
-  # continue: false -> start from scratch
+io:
   continue: true
 
 time:
-  time_save_dir: time/
-  n_output_digits: 8
   tend: 15000.0
   dt_output: 100.0
 
@@ -24,7 +18,6 @@ grid:
   z_max:  44.8
 
 mpi:
-  mpi_save_dir: mpi/
   x_procs: 2
   y_procs: 1
   z_procs: 1
@@ -36,8 +29,6 @@ domain:
     z: false
 
 mhd:
-  mhd_save_dir: mhd/
-  n_output_digits: 8
   cfl_number: 0.3
   artificial_viscosity:
     ep: 1.2

--- a/miso/include/miso/config.hpp
+++ b/miso/include/miso/config.hpp
@@ -12,6 +12,7 @@
 
 #include <yaml-cpp/yaml.h>
 
+#include "config_defaults.hpp"
 #include "env.hpp"
 #include "utility.hpp"
 
@@ -36,34 +37,28 @@ inline std::optional<std::string> parse_config_filepath(int argc, char **argv) {
   return std::nullopt;
 }
 
-/// @brief set default value for yaml node
-/// @tparam T type of the value
-/// @param root root yaml node
-/// @param path path to the target node
-/// @param value default value to set if the target node is not set
-template <typename T>
-void set_default_yaml_node(YAML::Node &root, const std::vector<std::string> &path,
-                           const T &value) {
-  if (path.size() == 1) {
-    if (!root[path[0]]) {
-      root[path[0]] = value;
-    }
+inline void merge_yaml(YAML::Node &target, const YAML::Node &defaults) {
+  if (!defaults.IsMap()) {
     return;
-  } else if (path.size() == 2) {
-    if (!root[path[0]][path[1]]) {
-      root[path[0]][path[1]] = value;
+  }
+
+  if (!target || !target.IsMap()) {
+    target = YAML::Node(YAML::NodeType::Map);
+  }
+
+  for (const auto &it : defaults) {
+    const std::string key = it.first.as<std::string>();
+    const YAML::Node &default_value = it.second;
+
+    if (default_value.IsMap()) {
+      YAML::Node child = target[key];
+      merge_yaml(child, default_value);
+      target[key] = child;
+    } else {
+      if (!target[key]) {
+        target[key] = default_value;
+      }
     }
-    return;
-  } else if (path.size() == 3) {
-    if (!root[path[0]][path[1]][path[2]]) {
-      root[path[0]][path[1]][path[2]] = value;
-    }
-    return;
-  } else if (path.empty()) {
-    throw std::invalid_argument("set_default_yaml_node: path cannot be empty");
-  } else {
-    throw std::invalid_argument(
-        "set_default_yaml_node: path size must be 1, 2, or 3");
   }
 }
 
@@ -109,7 +104,10 @@ struct Config {
       yaml_obj = YAML::Load(yaml_str);
     }
 
-    set_default();
+    // read default config from config_defaults.hpp
+    YAML::Node yaml_default_obj = YAML::Load(config_default_yaml);
+
+    merge_yaml(yaml_obj, yaml_default_obj);
 
     fs::path config_path = fs::absolute(load_filepath);
     fs::path config_dir = config_path.parent_path();
@@ -141,30 +139,6 @@ struct Config {
       out << yaml_obj;
       ofs << out.c_str();
     }
-  }
-
-private:
-  void set_default() {
-    // set default values started
-    set_default_yaml_node<bool>(yaml_obj, {"io", "enabled"}, true);
-    set_default_yaml_node<std::string>(yaml_obj, {"io", "save_dir"}, "data/");
-    set_default_yaml_node<std::string>(yaml_obj, {"io", "time_save_dir"},
-                                       "time/");
-    set_default_yaml_node<std::string>(yaml_obj, {"io", "mpi_save_dir"}, "mpi/");
-    set_default_yaml_node<std::string>(yaml_obj, {"io", "mhd_save_dir"}, "mhd/");
-    set_default_yaml_node<int>(yaml_obj, {"io", "n_output_digits"}, 8);
-    set_default_yaml_node<double>(yaml_obj, {"mhd", "cfl_number"}, 0.5);
-    set_default_yaml_node<double>(yaml_obj, {"mhd", "artificial_viscosity", "ep"},
-                                  1.0);
-    set_default_yaml_node<double>(yaml_obj, {"mhd", "artificial_viscosity", "fh"},
-                                  1.0);
-    set_default_yaml_node<double>(yaml_obj,
-                                  {"mhd", "artificial_viscosity", "cs_fac"}, 1.0);
-    set_default_yaml_node<double>(yaml_obj,
-                                  {"mhd", "artificial_viscosity", "ca_fac"}, 1.0);
-    set_default_yaml_node<double>(yaml_obj,
-                                  {"mhd", "artificial_viscosity", "vv_fac"}, 1.0);
-    // set default values finished
   }
 };
 

--- a/miso/include/miso/config.hpp
+++ b/miso/include/miso/config.hpp
@@ -32,6 +32,33 @@ inline std::optional<std::string> parse_config_filepath(int argc, char **argv) {
   return std::nullopt;
 }
 
+/// @brief set default value for yaml node
+/// @tparam T type of the value
+/// @param root root yaml node
+/// @param path path to the target node
+/// @param value default value to set if the target node is not set
+template <typename T>
+void set_default_yaml_node(YAML::Node &root, const std::vector<std::string> &path,
+                           const T &value) {
+  if (path.size() == 1) {
+    if (!root[path[0]]) {
+      root[path[0]] = value;
+    }
+    return;
+  } else if (path.size() == 2) {
+    if (!root[path[0]][path[1]]) {
+      root[path[0]][path[1]] = value;
+    }
+  } else if (path.size() == 3) {
+    if (!root[path[0]][path[1]][path[2]]) {
+      root[path[0]][path[1]][path[2]] = value;
+    }
+  } else {
+    throw std::runtime_error(
+        "set_default_yaml_node: path size must be 1, 2, or 3");
+  }
+}
+
 /// @brief Configuration class for MHD simulations
 struct Config {
   /// @brief file path for YAML configuration file
@@ -76,9 +103,26 @@ struct Config {
       yaml_obj = YAML::Load(yaml_str);
     }
 
-    if (!yaml_obj["io"]["enabled"]) {
-      yaml_obj["io"]["enabled"] = true;
-    }
+    // set default values started
+    set_default_yaml_node<bool>(yaml_obj, {"io", "enabled"}, true);
+    set_default_yaml_node<std::string>(yaml_obj, {"io", "save_dir"}, "data/");
+    set_default_yaml_node<std::string>(yaml_obj, {"io", "time_save_dir"},
+                                       "time/");
+    set_default_yaml_node<std::string>(yaml_obj, {"io", "mpi_save_dir"}, "mpi/");
+    set_default_yaml_node<std::string>(yaml_obj, {"io", "mhd_save_dir"}, "mhd/");
+    set_default_yaml_node<int>(yaml_obj, {"io", "n_output_digits"}, 8);
+    set_default_yaml_node<double>(yaml_obj, {"mhd", "cfl_number"}, 0.5);
+    set_default_yaml_node<double>(yaml_obj, {"mhd", "artificial_viscosity", "ep"},
+                                  1.0);
+    set_default_yaml_node<double>(yaml_obj, {"mhd", "artificial_viscosity", "fh"},
+                                  1.0);
+    set_default_yaml_node<double>(yaml_obj,
+                                  {"mhd", "artificial_viscosity", "cs_fac"}, 1.0);
+    set_default_yaml_node<double>(yaml_obj,
+                                  {"mhd", "artificial_viscosity", "ca_fac"}, 1.0);
+    set_default_yaml_node<double>(yaml_obj,
+                                  {"mhd", "artificial_viscosity", "vv_fac"}, 1.0);
+    // set default values finished
 
     fs::path config_path = fs::absolute(load_filepath);
     fs::path config_dir = config_path.parent_path();

--- a/miso/include/miso/config.hpp
+++ b/miso/include/miso/config.hpp
@@ -76,16 +76,16 @@ struct Config {
       yaml_obj = YAML::Load(yaml_str);
     }
 
-    if (!yaml_obj["base"]["io_enabled"]) {
-      yaml_obj["base"]["io_enabled"] = true;
+    if (!yaml_obj["io"]["enabled"]) {
+      yaml_obj["io"]["enabled"] = true;
     }
 
     fs::path config_path = fs::absolute(load_filepath);
     fs::path config_dir = config_path.parent_path();
 
     save_dir =
-        (config_dir / yaml_obj["base"]["save_dir"].as<std::string>()).string();
-    if (yaml_obj["base"]["io_enabled"].as<bool>()) {
+        (config_dir / yaml_obj["io"]["save_dir"].as<std::string>()).string();
+    if (yaml_obj["io"]["enabled"].as<bool>()) {
       util::create_directories(save_dir);
     }
   }
@@ -98,7 +98,7 @@ struct Config {
   /// @brief  Save the configuration to a YAML file
   void save() const {
     if (mpi::is_root()) {
-      if (!yaml_obj["base"]["io_enabled"].as<bool>()) {
+      if (!yaml_obj["io"]["enabled"].as<bool>()) {
         return;
       }
       std::string save_filepath = save_dir + "/config.yaml";

--- a/miso/include/miso/config.hpp
+++ b/miso/include/miso/config.hpp
@@ -3,8 +3,12 @@
 #include <cassert>
 #include <fstream>
 #include <optional>
+#include <sstream>
+#include <stdexcept>
 #include <string>
+#include <string_view>
 #include <type_traits>
+#include <vector>
 
 #include <yaml-cpp/yaml.h>
 
@@ -49,12 +53,16 @@ void set_default_yaml_node(YAML::Node &root, const std::vector<std::string> &pat
     if (!root[path[0]][path[1]]) {
       root[path[0]][path[1]] = value;
     }
+    return;
   } else if (path.size() == 3) {
     if (!root[path[0]][path[1]][path[2]]) {
       root[path[0]][path[1]][path[2]] = value;
     }
+    return;
+  } else if (path.empty()) {
+    throw std::invalid_argument("set_default_yaml_node: path cannot be empty");
   } else {
-    throw std::runtime_error(
+    throw std::invalid_argument(
         "set_default_yaml_node: path size must be 1, 2, or 3");
   }
 }
@@ -67,8 +75,6 @@ struct Config {
   YAML::Node yaml_obj;
   /// @brief Directories for saving parent results
   std::string save_dir;
-  /// @brief Directories for saving time information
-  std::string time_save_dir;
 
   Config(const std::string &load_filepath_) : load_filepath(load_filepath_) {
     std::string yaml_str;
@@ -91,7 +97,7 @@ struct Config {
       yaml_str = ss.str();
     }
 
-    int yaml_str_length = yaml_str.length();
+    int yaml_str_length = static_cast<int>(yaml_str.length());
     MPI_Bcast(&yaml_str_length, 1, MPI_INT, 0, MPI_COMM_WORLD);
 
     if (!mpi::is_root()) {
@@ -103,26 +109,7 @@ struct Config {
       yaml_obj = YAML::Load(yaml_str);
     }
 
-    // set default values started
-    set_default_yaml_node<bool>(yaml_obj, {"io", "enabled"}, true);
-    set_default_yaml_node<std::string>(yaml_obj, {"io", "save_dir"}, "data/");
-    set_default_yaml_node<std::string>(yaml_obj, {"io", "time_save_dir"},
-                                       "time/");
-    set_default_yaml_node<std::string>(yaml_obj, {"io", "mpi_save_dir"}, "mpi/");
-    set_default_yaml_node<std::string>(yaml_obj, {"io", "mhd_save_dir"}, "mhd/");
-    set_default_yaml_node<int>(yaml_obj, {"io", "n_output_digits"}, 8);
-    set_default_yaml_node<double>(yaml_obj, {"mhd", "cfl_number"}, 0.5);
-    set_default_yaml_node<double>(yaml_obj, {"mhd", "artificial_viscosity", "ep"},
-                                  1.0);
-    set_default_yaml_node<double>(yaml_obj, {"mhd", "artificial_viscosity", "fh"},
-                                  1.0);
-    set_default_yaml_node<double>(yaml_obj,
-                                  {"mhd", "artificial_viscosity", "cs_fac"}, 1.0);
-    set_default_yaml_node<double>(yaml_obj,
-                                  {"mhd", "artificial_viscosity", "ca_fac"}, 1.0);
-    set_default_yaml_node<double>(yaml_obj,
-                                  {"mhd", "artificial_viscosity", "vv_fac"}, 1.0);
-    // set default values finished
+    set_default();
 
     fs::path config_path = fs::absolute(load_filepath);
     fs::path config_dir = config_path.parent_path();
@@ -154,6 +141,30 @@ struct Config {
       out << yaml_obj;
       ofs << out.c_str();
     }
+  }
+
+private:
+  void set_default() {
+    // set default values started
+    set_default_yaml_node<bool>(yaml_obj, {"io", "enabled"}, true);
+    set_default_yaml_node<std::string>(yaml_obj, {"io", "save_dir"}, "data/");
+    set_default_yaml_node<std::string>(yaml_obj, {"io", "time_save_dir"},
+                                       "time/");
+    set_default_yaml_node<std::string>(yaml_obj, {"io", "mpi_save_dir"}, "mpi/");
+    set_default_yaml_node<std::string>(yaml_obj, {"io", "mhd_save_dir"}, "mhd/");
+    set_default_yaml_node<int>(yaml_obj, {"io", "n_output_digits"}, 8);
+    set_default_yaml_node<double>(yaml_obj, {"mhd", "cfl_number"}, 0.5);
+    set_default_yaml_node<double>(yaml_obj, {"mhd", "artificial_viscosity", "ep"},
+                                  1.0);
+    set_default_yaml_node<double>(yaml_obj, {"mhd", "artificial_viscosity", "fh"},
+                                  1.0);
+    set_default_yaml_node<double>(yaml_obj,
+                                  {"mhd", "artificial_viscosity", "cs_fac"}, 1.0);
+    set_default_yaml_node<double>(yaml_obj,
+                                  {"mhd", "artificial_viscosity", "ca_fac"}, 1.0);
+    set_default_yaml_node<double>(yaml_obj,
+                                  {"mhd", "artificial_viscosity", "vv_fac"}, 1.0);
+    // set default values finished
   }
 };
 

--- a/miso/include/miso/config.hpp
+++ b/miso/include/miso/config.hpp
@@ -8,7 +8,6 @@
 #include <string>
 #include <string_view>
 #include <type_traits>
-#include <vector>
 
 #include <yaml-cpp/yaml.h>
 

--- a/miso/include/miso/config_defaults.hpp
+++ b/miso/include/miso/config_defaults.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+namespace miso {
+inline constexpr const char *config_default_yaml = R"yaml(
+io:
+  # Whether to enable I/O operations
+  enabled: true
+  # Directory for saving all output files
+  save_dir: data/
+  # Directory for saving time-related files
+  time_save_dir: time/
+  # Directory for saving MPI-related files
+  mpi_save_dir: mpi/
+  # Directory for saving MHD simulation checkpoint files
+  mhd_save_dir: mhd/
+  # Number of digits for output file naming (e.g., 8 means 00000001)
+  n_output_digits: 8
+
+mhd:
+    # CFL number for time-stepping
+    cfl_number: 0.5
+    artificial_viscosity:
+        # ep and fh represent epsilon and h in Rempel, 2014, ApJ, 789, 132, in Rempel, 2014, epsilon =2
+        ep: 1.0
+        fh: 1.0
+        # factors for controlling the strength of artificial viscosity for different chracteristic velocities
+        cs_fac: 1.0
+        ca_fac: 1.0
+        vv_fac: 1.0
+    )yaml";
+}

--- a/miso/include/miso/config_defaults.hpp
+++ b/miso/include/miso/config_defaults.hpp
@@ -23,7 +23,7 @@ mhd:
         # ep and fh represent epsilon and h in Rempel, 2014, ApJ, 789, 132, in Rempel, 2014, epsilon =2
         ep: 1.0
         fh: 1.0
-        # factors for controlling the strength of artificial viscosity for different chracteristic velocities
+        # factors for controlling the strength of artificial viscosity for different characteristic velocities
         cs_fac: 1.0
         ca_fac: 1.0
         vv_fac: 1.0

--- a/miso/include/miso/config_defaults.hpp
+++ b/miso/include/miso/config_defaults.hpp
@@ -20,7 +20,7 @@ mhd:
     # CFL number for time-stepping
     cfl_number: 0.5
     artificial_viscosity:
-        # ep and fh represent epsilon and h in Rempel, 2014, ApJ, 789, 132, in Rempel, 2014, epsilon =2
+        # ep and fh represent epsilon and h in Rempel, 2014, ApJ, 789, 132. In Rempel, 2014, epsilon = 2 is implicitly used in eq. (8).
         ep: 1.0
         fh: 1.0
         # factors for controlling the strength of artificial viscosity for different characteristic velocities

--- a/miso/include/miso/grid.hpp
+++ b/miso/include/miso/grid.hpp
@@ -384,7 +384,7 @@ template <typename Real> struct Grid<Real, backend::Host> {
   /// @param config
   void save(const Config &config) const {
     if (mpi::is_root()) {
-      if (!config.yaml_obj["base"]["io_enabled"].as<bool>()) {
+      if (!config.yaml_obj["io"]["enabled"].as<bool>()) {
         return;
       }
 

--- a/miso/include/miso/mhd_checkpoint.hpp
+++ b/miso/include/miso/mhd_checkpoint.hpp
@@ -19,10 +19,10 @@ template <typename Real> struct Checkpoint {
   bool io_enabled;
 
   Checkpoint(Config &config, Grid<Real, backend::Host> &grid)
-      : qq(grid), io_enabled(config.yaml_obj["base"]["io_enabled"].as<bool>()) {
-    n_output_digits = config["mhd"]["n_output_digits"].as<int>();
+      : qq(grid), io_enabled(config.yaml_obj["io"]["enabled"].as<bool>()) {
+    n_output_digits = config["io"]["n_output_digits"].as<int>();
     mhd_save_dir =
-        config.save_dir + config["mhd"]["mhd_save_dir"].as<std::string>();
+        config.save_dir + config["io"]["mhd_save_dir"].as<std::string>();
   }
 
   std::string get_filename(const Time<Real> &time) const {

--- a/miso/include/miso/mhd_model_base.hpp
+++ b/miso/include/miso/mhd_model_base.hpp
@@ -102,7 +102,7 @@ public:
 
     mhd.apply_initial_condition(d.ic, d.bc);
     if (config["io"]["continue"].as<bool>() &&
-        fs::exists(time.time_save_dir + "n_output.txt")) {
+        fs::exists(fs::path(time.time_save_dir) / "n_output.txt")) {
       load_state();
     }
 

--- a/miso/include/miso/mhd_model_base.hpp
+++ b/miso/include/miso/mhd_model_base.hpp
@@ -101,7 +101,7 @@ public:
                   "Derived must have member variable 'src'.");
 
     mhd.apply_initial_condition(d.ic, d.bc);
-    if (config["base"]["continue"].as<bool>() &&
+    if (config["io"]["continue"].as<bool>() &&
         fs::exists(time.time_save_dir + "n_output.txt")) {
       load_state();
     }

--- a/miso/include/miso/mpi_util.hpp
+++ b/miso/include/miso/mpi_util.hpp
@@ -60,8 +60,8 @@ struct Shape {
   Shape(const Config &config) {
 
     mpi_save_dir =
-        config.save_dir + config["mpi"]["mpi_save_dir"].as<std::string>();
-    io_enabled = config.yaml_obj["base"]["io_enabled"].as<bool>();
+        config.save_dir + config["io"]["mpi_save_dir"].as<std::string>();
+    io_enabled = config.yaml_obj["io"]["enabled"].as<bool>();
     if (io_enabled) {
       util::create_directories(mpi_save_dir);
     }

--- a/miso/include/miso/time.hpp
+++ b/miso/include/miso/time.hpp
@@ -44,15 +44,15 @@ template <typename Real> struct Time {
   Time(const Config &config)
       : tend(config["time"]["tend"].as<Real>()),
         dt_output(config["time"]["dt_output"].as<Real>()),
-        n_output_digits(config["time"]["n_output_digits"].as<int>()),
-        io_enabled(config.yaml_obj["base"]["io_enabled"].as<bool>()) {
+        n_output_digits(config["io"]["n_output_digits"].as<int>()),
+        io_enabled(config.yaml_obj["io"]["enabled"].as<bool>()) {
     assert(tend > 0);
     assert(dt_output > 0);
 
     initialize();
 
     time_save_dir =
-        config.save_dir + config["time"]["time_save_dir"].as<std::string>();
+        config.save_dir + config["io"]["time_save_dir"].as<std::string>();
     if (io_enabled) {
       util::create_directories(time_save_dir);
     }

--- a/miso/tests/parallel/config/config_mpi_x.yaml
+++ b/miso/tests/parallel/config/config_mpi_x.yaml
@@ -1,11 +1,13 @@
-base:
+io:
   save_dir: data/
+  time_save_dir: time/
+  mhd_save_dir: mhd/
+  mpi_save_dir: mpi/
+  n_procs_digits: 8
 
 time:
-  time_save_dir: time/
   tend: 0.2
   dt_output: 0.01
-  n_output_digits: 8
 
 grid:
   i_size: 4
@@ -20,7 +22,6 @@ grid:
   z_max: 1.0
 
 mhd:
-  mhd_save_dir: mhd/
 
 eos:
   gm: 1.4
@@ -29,8 +30,6 @@ time_integrator:
   cfl_number: 0.5
 
 mpi:
-  mpi_save_dir: mpi/
-  n_procs_digits: 8
   x_procs: 2
   y_procs: 1
   z_procs: 1

--- a/miso/tests/parallel/config/config_mpi_x.yaml
+++ b/miso/tests/parallel/config/config_mpi_x.yaml
@@ -1,5 +1,5 @@
 io:
-  contiune: false
+  continue: false
 
 time:
   tend: 0.2

--- a/miso/tests/parallel/config/config_mpi_x.yaml
+++ b/miso/tests/parallel/config/config_mpi_x.yaml
@@ -1,9 +1,5 @@
 io:
-  save_dir: data/
-  time_save_dir: time/
-  mhd_save_dir: mhd/
-  mpi_save_dir: mpi/
-  n_procs_digits: 8
+  contiune: false
 
 time:
   tend: 0.2
@@ -26,9 +22,6 @@ mhd:
 eos:
   gm: 1.4
 
-time_integrator:
-  cfl_number: 0.5
-
 mpi:
   x_procs: 2
   y_procs: 1
@@ -39,7 +32,3 @@ domain:
     x: false
     y: false
     z: false
-
-artificial_viscosity:
-  ep: 1.0
-  fh: 1.0

--- a/miso/tests/parallel/config/config_mpi_y.yaml
+++ b/miso/tests/parallel/config/config_mpi_y.yaml
@@ -1,11 +1,13 @@
-base:
+io:
   save_dir: data/
+  time_save_dir: time/
+  mhd_save_dir: mhd/
+  mpi_save_dir: mpi/
+  n_procs_digits: 8
 
 time:
-  time_save_dir: time/
   tend: 0.2
   dt_output: 0.01
-  n_output_digits: 8
 
 grid:
   i_size: 6
@@ -20,7 +22,6 @@ grid:
   z_max: 1.0
 
 mhd:
-  mhd_save_dir: mhd/
 
 eos:
   gm: 1.4
@@ -29,8 +30,6 @@ time_integrator:
   cfl_number: 0.5
 
 mpi:
-  mpi_save_dir: mpi/
-  n_procs_digits: 8
   x_procs: 1
   y_procs: 2
   z_procs: 1

--- a/miso/tests/parallel/config/config_mpi_y.yaml
+++ b/miso/tests/parallel/config/config_mpi_y.yaml
@@ -1,9 +1,5 @@
 io:
-  save_dir: data/
-  time_save_dir: time/
-  mhd_save_dir: mhd/
-  mpi_save_dir: mpi/
-  n_procs_digits: 8
+  continue: false
 
 time:
   tend: 0.2
@@ -26,9 +22,6 @@ mhd:
 eos:
   gm: 1.4
 
-time_integrator:
-  cfl_number: 0.5
-
 mpi:
   x_procs: 1
   y_procs: 2
@@ -39,7 +32,3 @@ domain:
     x: false
     y: false
     z: false
-
-artificial_viscosity:
-  ep: 1.0
-  fh: 1.0

--- a/miso/tests/parallel/config/config_mpi_z.yaml
+++ b/miso/tests/parallel/config/config_mpi_z.yaml
@@ -6,9 +6,9 @@ time:
   dt_output: 0.01
 
 grid:
-  i_size: 4
-  j_size: 5
-  k_size: 6
+  i_size: 5
+  j_size: 6
+  k_size: 4
   margin: 2
   x_min: 0.0
   x_max: 1.0

--- a/miso/tests/parallel/config/config_mpi_z.yaml
+++ b/miso/tests/parallel/config/config_mpi_z.yaml
@@ -1,9 +1,5 @@
 io:
-  save_dir: data/
-  time_save_dir: time/
-  mhd_save_dir: mhd/
-  mpi_save_dir: mpi/
-  n_procs_digits: 8
+  continue: false
 
 time:
   tend: 0.2
@@ -26,9 +22,6 @@ mhd:
 eos:
   gm: 1.4
 
-time_integrator:
-  cfl_number: 0.5
-
 mpi:
   x_procs: 1
   y_procs: 1
@@ -39,7 +32,3 @@ domain:
     x: false
     y: false
     z: false
-
-artificial_viscosity:
-  ep: 1.0
-  fh: 1.0

--- a/miso/tests/parallel/config/config_mpi_z.yaml
+++ b/miso/tests/parallel/config/config_mpi_z.yaml
@@ -1,16 +1,18 @@
-base:
+io:
   save_dir: data/
+  time_save_dir: time/
+  mhd_save_dir: mhd/
+  mpi_save_dir: mpi/
+  n_procs_digits: 8
 
 time:
-  time_save_dir: time/
   tend: 0.2
   dt_output: 0.01
-  n_output_digits: 8
 
 grid:
-  i_size: 5
-  j_size: 6
-  k_size: 4
+  i_size: 4
+  j_size: 5
+  k_size: 6
   margin: 2
   x_min: 0.0
   x_max: 1.0
@@ -20,7 +22,6 @@ grid:
   z_max: 1.0
 
 mhd:
-  mhd_save_dir: mhd/
 
 eos:
   gm: 1.4
@@ -29,8 +30,6 @@ time_integrator:
   cfl_number: 0.5
 
 mpi:
-  mpi_save_dir: mpi/
-  n_procs_digits: 8
   x_procs: 1
   y_procs: 1
   z_procs: 2

--- a/miso/tests/serial/test_hd1d_shock_tube/config/config_x.yaml
+++ b/miso/tests/serial/test_hd1d_shock_tube/config/config_x.yaml
@@ -1,11 +1,13 @@
-base:
-  io_enabled: false
-  save_dir: ../data_x/
+io:
+  enabled: false
   continue: false
+  save_dir: ../data_x/
+  time_save_dir: time/
+  mpi_save_dir: mpi/
+  mhd_save_dir: mhd/
+  n_output_digits: 8
 
 time:
-  time_save_dir: time/
-  n_output_digits: 8
   tend: 0.2
   dt_output: 0.01
 
@@ -22,7 +24,6 @@ grid:
   z_max: 1.0
 
 mpi:
-  mpi_save_dir: mpi/
   x_procs: 1
   y_procs: 1
   z_procs: 1
@@ -34,7 +35,6 @@ domain:
     z: false
 
 mhd:
-  mhd_save_dir: mhd/
   n_output_digits: 8
   cfl_number: 0.5
   artificial_viscosity:

--- a/miso/tests/serial/test_hd1d_shock_tube/config/config_x.yaml
+++ b/miso/tests/serial/test_hd1d_shock_tube/config/config_x.yaml
@@ -2,10 +2,6 @@ io:
   enabled: false
   continue: false
   save_dir: ../data_x/
-  time_save_dir: time/
-  mpi_save_dir: mpi/
-  mhd_save_dir: mhd/
-  n_output_digits: 8
 
 time:
   tend: 0.2
@@ -35,15 +31,6 @@ domain:
     z: false
 
 mhd:
-  n_output_digits: 8
-  cfl_number: 0.5
-  artificial_viscosity:
-    ep: 1.0
-    fh: 1.0
-    # for characteristic velocity
-    cs_fac: 1.0
-    ca_fac: 1.0
-    vv_fac: 1.0
 
 eos:
   gm: 1.4

--- a/miso/tests/serial/test_hd1d_shock_tube/config/config_y.yaml
+++ b/miso/tests/serial/test_hd1d_shock_tube/config/config_y.yaml
@@ -1,11 +1,13 @@
-base:
-  io_enabled: false
-  save_dir: ../data_y/
+io:
+  enabled: false
   continue: false
+  save_dir: ../data_y/
+  time_save_dir: time/
+  mpi_save_dir: mpi/
+  mhd_save_dir: mhd/
+  n_output_digits: 8
 
 time:
-  time_save_dir: time/
-  n_output_digits: 8
   tend: 0.2
   dt_output: 0.01
 
@@ -22,7 +24,6 @@ grid:
   z_max: 1.0
 
 mpi:
-  mpi_save_dir: mpi/
   x_procs: 1
   y_procs: 1
   z_procs: 1
@@ -34,7 +35,6 @@ domain:
     z: false
 
 mhd:
-  mhd_save_dir: mhd/
   n_output_digits: 8
   cfl_number: 0.5
   artificial_viscosity:

--- a/miso/tests/serial/test_hd1d_shock_tube/config/config_y.yaml
+++ b/miso/tests/serial/test_hd1d_shock_tube/config/config_y.yaml
@@ -2,10 +2,6 @@ io:
   enabled: false
   continue: false
   save_dir: ../data_y/
-  time_save_dir: time/
-  mpi_save_dir: mpi/
-  mhd_save_dir: mhd/
-  n_output_digits: 8
 
 time:
   tend: 0.2
@@ -35,15 +31,6 @@ domain:
     z: false
 
 mhd:
-  n_output_digits: 8
-  cfl_number: 0.5
-  artificial_viscosity:
-    ep: 1.0
-    fh: 1.0
-    # for characteristic velocity
-    cs_fac: 1.0
-    ca_fac: 1.0
-    vv_fac: 1.0
 
 eos:
   gm: 1.4

--- a/miso/tests/serial/test_hd1d_shock_tube/config/config_z.yaml
+++ b/miso/tests/serial/test_hd1d_shock_tube/config/config_z.yaml
@@ -1,11 +1,13 @@
-base:
-  io_enabled: false
-  save_dir: ../data_z/
+io:
+  enabled: false
   continue: false
+  save_dir: ../data_z/
+  time_save_dir: time/
+  mpi_save_dir: mpi/
+  mhd_save_dir: mhd/
+  n_output_digits: 8
 
 time:
-  time_save_dir: time/
-  n_output_digits: 8
   tend: 0.2
   dt_output: 0.01
 
@@ -22,7 +24,6 @@ grid:
   z_max: 1.0
 
 mpi:
-  mpi_save_dir: mpi/
   x_procs: 1
   y_procs: 1
   z_procs: 1
@@ -34,7 +35,6 @@ domain:
     z: false
 
 mhd:
-  mhd_save_dir: mhd/
   n_output_digits: 8
   cfl_number: 0.5
   artificial_viscosity:

--- a/miso/tests/serial/test_hd1d_shock_tube/config/config_z.yaml
+++ b/miso/tests/serial/test_hd1d_shock_tube/config/config_z.yaml
@@ -2,10 +2,6 @@ io:
   enabled: false
   continue: false
   save_dir: ../data_z/
-  time_save_dir: time/
-  mpi_save_dir: mpi/
-  mhd_save_dir: mhd/
-  n_output_digits: 8
 
 time:
   tend: 0.2
@@ -35,15 +31,6 @@ domain:
     z: false
 
 mhd:
-  n_output_digits: 8
-  cfl_number: 0.5
-  artificial_viscosity:
-    ep: 1.0
-    fh: 1.0
-    # for characteristic velocity
-    cs_fac: 1.0
-    ca_fac: 1.0
-    vv_fac: 1.0
 
 eos:
   gm: 1.4

--- a/pymiso/conf.py
+++ b/pymiso/conf.py
@@ -32,7 +32,7 @@ class Conf:
         for group, values in config.items():
             setattr(self, group, values)
 
-        self.time_data_dir = self.data_dir / self.time.time_save_dir
-        self.mhd_data_dir = self.data_dir / self.mhd.mhd_save_dir
-        self.mpi_data_dir = self.data_dir / self.mpi.mpi_save_dir
+        self.time_data_dir = self.data_dir / self.io.time_save_dir
+        self.mhd_data_dir = self.data_dir / self.io.mhd_save_dir
+        self.mpi_data_dir = self.data_dir / self.io.mpi_save_dir
         self.endian = "<" if self.data_type.Endian == "little" else ">"

--- a/pymiso/data.py
+++ b/pymiso/data.py
@@ -47,8 +47,8 @@ class Data:
 
         for rank in range(self.mpi.n_procs):
             filename = self.conf.mhd_data_dir / (
-                f"mhd.{n_output:0{self.conf.time.n_output_digits}d}"
-                f".{rank:0{self.conf.mhd.n_output_digits}d}.bin"
+                f"mhd.{n_output:0{self.conf.io.n_output_digits}d}"
+                f".{rank:0{self.conf.io.n_output_digits}d}.bin"
             )
 
             if self.mpi.n_procs > 1:

--- a/pymiso/time.py
+++ b/pymiso/time.py
@@ -20,6 +20,7 @@ class Time:
             setattr(self, group, values)
 
         self.time_data_dir = conf.time_data_dir
+        self.n_output_digits = conf.io.n_output_digits
         with (self.time_data_dir / "n_output.txt").open("r") as f:
             self.n_output = int(f.readline())
 


### PR DESCRIPTION


config.yamlの再検討をしました。
`demo/hd1d_shock_tube/config/config_x.yaml`などをみていただくと良いと思います。

- `base` -> `io`
- ディレクトリ指定系はすべて`io`以下に配置
- `n_procs_digits`も`io`に移動。この`n_procs_digits`は少しカッコ悪いかもと思ってきました。

hd1_shock_tube以外のdemoは治していません。この方針でよければ他も直します。

デフォルト値を設定すると良さそうなもの
```yaml
io:
  enabled: true
  save_dir: ../data_x/
  time_save_dir: time/
  mpi_save_dir: mpi/
  mhd_save_dir: mhd/
  n_output_digits: 8

mhd:
  cfl_number: 0.5
  artificial_viscosity:
    ep: 1.0
    fh: 1.0
    # for characteristic velocity
    cs_fac: 1.0
    ca_fac: 1.0
    vv_fac: 1.0
```
